### PR TITLE
add missing TruffleBoundary and transferToInterpreter

### DIFF
--- a/projects/com.nvidia.grcuda/.checkstyle_checks.xml
+++ b/projects/com.nvidia.grcuda/.checkstyle_checks.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+  Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
 
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions
@@ -56,12 +57,6 @@
       <property name="format" value="^[A-Z][_a-zA-Z0-9]*$"/>
     </module>
     <module name="AvoidStarImport"/>
-    <module name="ImportOrder">
-      <property name="groups" value="/^java\./,javax,org"/>
-      <property name="ordered" value="true"/>
-      <property name="option" value="above"/>
-      <property name="sortStaticImportsAlphabetically" value="true"/>
-    </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
     <module name="LineLength">

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/ElementType.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/ElementType.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,6 +27,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.nvidia.grcuda;
+
+import com.oracle.truffle.api.CompilerDirectives;
 
 public enum ElementType {
     BYTE(1),
@@ -61,6 +64,7 @@ public enum ElementType {
             case "double":
                 return ElementType.DOUBLE;
             default:
+                CompilerDirectives.transferToInterpreter();
                 throw new TypeException("invalid type '" + type + "'");
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/MultiDimDeviceArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/MultiDimDeviceArray.java
@@ -72,6 +72,7 @@ public class MultiDimDeviceArray implements TruffleObject {
     public MultiDimDeviceArray(CUDARuntime runtime, ElementType elementType, long[] dimensions,
                     boolean useColumnMajor) {
         if (dimensions.length < 2) {
+            CompilerDirectives.transferToInterpreter();
             throw new IllegalArgumentException(
                             "MultiDimDeviceArray requires at least two dimension, use DeviceArray instead");
         }
@@ -79,6 +80,7 @@ public class MultiDimDeviceArray implements TruffleObject {
         long prod = 1;
         for (long n : dimensions) {
             if (n < 1) {
+                CompilerDirectives.transferToInterpreter();
                 throw new IllegalArgumentException("invalid size of dimension " + n);
             }
             prod *= n;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/TypeException.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/TypeException.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,12 +28,15 @@
  */
 package com.nvidia.grcuda;
 
+import com.oracle.truffle.api.CompilerAsserts;
+
 public class TypeException extends Exception {
 
     private static final long serialVersionUID = -7313402629647154160L;
 
     TypeException(String message) {
         super(message);
+        CompilerAsserts.neverPartOfCompilation();
     }
 
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cuml/CUMLRegistry.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cuml/CUMLRegistry.java
@@ -37,6 +37,7 @@ import com.nvidia.grcuda.functions.Function;
 import com.nvidia.grcuda.functions.FunctionTable;
 import com.nvidia.grcuda.gpu.CUDAException;
 import com.nvidia.grcuda.gpu.UnsafeHelper;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.ArityException;
@@ -95,6 +96,7 @@ public class CUMLRegistry {
                         return handle.getValue();
                     }
                 } catch (InteropException e) {
+                    CompilerDirectives.transferToInterpreter();
                     throw new RuntimeException(e);
                 }
             }
@@ -114,6 +116,7 @@ public class CUMLRegistry {
                     checkCUMLReturnCode(result, "cumlDestroy");
                     return result;
                 } catch (InteropException e) {
+                    CompilerDirectives.transferToInterpreter();
                     throw new RuntimeException(e);
                 }
             }
@@ -136,6 +139,7 @@ public class CUMLRegistry {
                             cumlHandle = expectInt(result);
                         }
                     } catch (InteropException e) {
+                        CompilerDirectives.transferToInterpreter();
                         throw new RuntimeException(e);
                     }
 
@@ -150,6 +154,7 @@ public class CUMLRegistry {
                         checkCUMLReturnCode(result, nfiFunction.getName());
                         return result;
                     } catch (InteropException e) {
+                        CompilerDirectives.transferToInterpreter();
                         throw new RuntimeException(e);
                     }
                 }
@@ -164,6 +169,7 @@ public class CUMLRegistry {
                 Object result = INTEROP.execute(cumlDestroyFunction, cumlHandle);
                 checkCUMLReturnCode(result, CUMLFunctionNFI.CUML_CUMLDESTROY.getFunctionFactory().getName());
             } catch (InteropException e) {
+                CompilerDirectives.transferToInterpreter();
                 throw new RuntimeException(e);
             }
         }
@@ -174,9 +180,11 @@ public class CUMLRegistry {
         try {
             returnCode = INTEROP.asInt(result);
         } catch (UnsupportedMessageException e) {
+            CompilerDirectives.transferToInterpreter();
             throw new RuntimeException("expected return code as Integer object in " + function + ", got " + result.getClass().getName());
         }
         if (returnCode != 0) {
+            CompilerDirectives.transferToInterpreter();
             throw new CUDAException(returnCode, cumlReturnCodeToString(returnCode), function);
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/BindFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/BindFunction.java
@@ -30,6 +30,7 @@ package com.nvidia.grcuda.functions;
 
 import com.nvidia.grcuda.GrCUDALanguage;
 import com.nvidia.grcuda.gpu.CUDAException;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
@@ -52,6 +53,7 @@ public final class BindFunction extends Function {
         try {
             return GrCUDALanguage.getCurrentLanguage().getContextReference().get().getCUDARuntime().getSymbol(libraryFile, symbolName, signature);
         } catch (UnknownIdentifierException e) {
+            CompilerDirectives.transferToInterpreter();
             throw new CUDAException(symbolName + " not found in " + libraryFile);
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayFunction.java
@@ -30,6 +30,7 @@ package com.nvidia.grcuda.functions;
 
 import java.util.ArrayList;
 import java.util.Optional;
+
 import com.nvidia.grcuda.DeviceArray;
 import com.nvidia.grcuda.ElementType;
 import com.nvidia.grcuda.MultiDimDeviceArray;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/ExternalFunctionFactory.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/ExternalFunctionFactory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +29,7 @@
 package com.nvidia.grcuda.functions;
 
 import com.nvidia.grcuda.gpu.CUDARuntime;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.InteropException;
 
 public class ExternalFunctionFactory {
@@ -65,6 +67,7 @@ public class ExternalFunctionFactory {
             return new ExternalFunction(name, namespace,
                             cudaRuntime.getSymbol(libraryPath, symbolName, nfiSignature));
         } catch (InteropException e) {
+            CompilerDirectives.transferToInterpreter();
             throw new RuntimeException(e);
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/Function.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/Function.java
@@ -73,6 +73,7 @@ public abstract class Function implements TruffleObject {
         try {
             return INTEROP.asInt(number);
         } catch (UnsupportedMessageException e) {
+            CompilerDirectives.transferToInterpreter();
             throw UnsupportedTypeException.create(new Object[]{number}, "expected integer number argument");
         }
     }
@@ -81,6 +82,7 @@ public abstract class Function implements TruffleObject {
         try {
             return INTEROP.asLong(number);
         } catch (UnsupportedMessageException e) {
+            CompilerDirectives.transferToInterpreter();
             throw UnsupportedTypeException.create(new Object[]{number}, message);
         }
     }
@@ -91,6 +93,7 @@ public abstract class Function implements TruffleObject {
 
     protected static void checkArgumentLength(Object[] arguments, int expected) throws ArityException {
         if (arguments.length != expected) {
+            CompilerDirectives.transferToInterpreter();
             throw ArityException.create(expected, arguments.length);
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/FunctionTable.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/FunctionTable.java
@@ -30,6 +30,8 @@ package com.nvidia.grcuda.functions;
 
 import java.util.HashMap;
 import java.util.Optional;
+
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
 public final class FunctionTable {
@@ -57,6 +59,7 @@ public final class FunctionTable {
     }
 
     private static String getKeyFromName(String functionName, String namespace) {
+        CompilerAsserts.neverPartOfCompilation();
         return namespace + "::" + functionName;
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
@@ -36,6 +36,7 @@ import com.nvidia.grcuda.GrCUDAContext;
 import com.nvidia.grcuda.functions.CUDAFunction;
 import com.nvidia.grcuda.functions.CUDAFunctionFactory;
 import com.nvidia.grcuda.functions.FunctionTable;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.interop.ArityException;
@@ -235,12 +236,14 @@ public final class CUDARuntime {
 
     private void checkCUDAReturnCode(Object result, String function) {
         if (!(result instanceof Integer)) {
+            CompilerDirectives.transferToInterpreter();
             throw new RuntimeException(
                             "expected return code as Integer object in " + function + ", got " +
                                             result.getClass().getName());
         }
         Integer returnCode = (Integer) result;
         if (returnCode != 0) {
+            CompilerDirectives.transferToInterpreter();
             throw new CUDAException(returnCode, cudaGetErrorString(returnCode), function);
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/ConfiguredKernel.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/ConfiguredKernel.java
@@ -28,6 +28,7 @@
  */
 package com.nvidia.grcuda.gpu;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
@@ -53,6 +54,7 @@ public class ConfiguredKernel implements TruffleObject {
     }
 
     @ExportMessage
+    @TruffleBoundary
     Object execute(Object[] arguments,
                     @CachedLibrary(limit = "3") InteropLibrary int32Access,
                     @CachedLibrary(limit = "3") InteropLibrary int64Access,

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Kernel.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Kernel.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import com.nvidia.grcuda.DeviceArray;
 import com.nvidia.grcuda.DeviceArray.MemberSet;
 import com.nvidia.grcuda.gpu.UnsafeHelper.MemoryObject;
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.Specialization;
@@ -136,6 +137,7 @@ public final class Kernel implements TruffleObject {
                         break;
                 }
             } catch (UnsupportedMessageException e) {
+                CompilerDirectives.transferToInterpreter();
                 throw UnsupportedTypeException.create(new Object[]{args[argIdx]}, "expected " + type);
             }
         }
@@ -143,6 +145,7 @@ public final class Kernel implements TruffleObject {
     }
 
     private static ArgumentType[] parseSignature(String kernelSignature) {
+        CompilerAsserts.neverPartOfCompilation();
         ArrayList<ArgumentType> args = new ArrayList<>();
         for (String s : kernelSignature.trim().split(",")) {
             ArgumentType type;
@@ -323,6 +326,7 @@ public final class Kernel implements TruffleObject {
             // dynamic shared memory specified
             dynamicSharedMemoryBytes = extractNumber(arguments[2], "dynamicSharedMemory", sharedMemoryAccess);
         } else {
+            CompilerDirectives.transferToInterpreter();
             throw ArityException.create(2, arguments.length);
         }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/KernelConfig.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/KernelConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +30,8 @@ package com.nvidia.grcuda.gpu;
 
 import java.util.Arrays;
 import java.util.Objects;
+
+import com.oracle.truffle.api.CompilerAsserts;
 
 public final class KernelConfig {
     private final Dim3 gridSize;
@@ -132,6 +135,7 @@ final class Dim3 {
 
     @Override
     public String toString() {
+        CompilerAsserts.neverPartOfCompilation();
         return "(" + dims[0] + ", " + dims[1] + ", " + dims[2] + ")";
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/NVRuntimeCompiler.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/NVRuntimeCompiler.java
@@ -31,6 +31,7 @@ package com.nvidia.grcuda.gpu;
 import java.util.ArrayList;
 import com.nvidia.grcuda.gpu.UnsafeHelper.PointerArray;
 import com.nvidia.grcuda.gpu.UnsafeHelper.StringObject;
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -49,6 +50,7 @@ public class NVRuntimeCompiler {
         this.runtime = runtime;
     }
 
+    @TruffleBoundary
     public PTXKernel compileKernel(String code, String kernelName, String moduleName, String... compileOpts) {
         try (NVRTCProgram program = createProgram(code, moduleName)) {
             nvrtcAddNameExpression(program, kernelName);
@@ -222,6 +224,7 @@ public class NVRuntimeCompiler {
     }
 
     private void checkNVRTCReturnCode(Object result, String functionName) {
+        CompilerAsserts.neverPartOfCompilation();
         if (!(result instanceof Integer)) {
             throw new RuntimeException(
                             "expected return code as Integer object in " + functionName + ", got " +
@@ -234,6 +237,7 @@ public class NVRuntimeCompiler {
     }
 
     private static NVRTCResult toNVRTCResult(Object result) {
+        CompilerAsserts.neverPartOfCompilation();
         if (!(result instanceof Integer)) {
             throw new RuntimeException(
                             "expected return code as Integer object for nvrtcResult, got " +

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArithmeticNode.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArithmeticNode.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +28,7 @@
  */
 package com.nvidia.grcuda.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 public final class ArithmeticNode extends BinaryNode {
@@ -52,6 +54,7 @@ public final class ArithmeticNode extends BinaryNode {
         Object left = leftNode.execute(frame);
         Object right = rightNode.execute(frame);
         if (!(left instanceof Number) || !(right instanceof Number)) {
+            CompilerDirectives.transferToInterpreter();
             throw new RuntimeException("operation expects integer types");
         }
         int leftInt = ((Number) left).intValue();
@@ -69,6 +72,7 @@ public final class ArithmeticNode extends BinaryNode {
             case MODULO:
                 return leftInt % rightInt;
         }
+        CompilerDirectives.transferToInterpreter();
         throw new RuntimeException("fall-through in ArithmeticNode");
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArrayNode.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArrayNode.java
@@ -35,6 +35,7 @@ import com.nvidia.grcuda.GrCUDAContext;
 import com.nvidia.grcuda.GrCUDALanguage;
 import com.nvidia.grcuda.MultiDimDeviceArray;
 import com.nvidia.grcuda.gpu.CUDARuntime;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -60,6 +61,7 @@ public abstract class ArrayNode extends ExpressionNode {
         for (ExpressionNode sizeNode : sizeNodes) {
             Object size = sizeNode.execute(frame);
             if (!(size instanceof Number)) {
+                CompilerDirectives.transferToInterpreter();
                 throw new RuntimeException("size in dimension " + dim + " must be a number");
             }
             elementsPerDim[dim] = ((Number) size).longValue();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/CallNode.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/CallNode.java
@@ -34,6 +34,7 @@ import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.GrCUDALanguage;
 import com.nvidia.grcuda.functions.Function;
 import com.nvidia.grcuda.functions.FunctionTable;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.CachedContext;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -62,6 +63,7 @@ public abstract class CallNode extends ExpressionNode {
         FunctionTable table = context.getFunctionTable();
         Optional<Function> maybeFunction = table.lookupFunction(functionName, namespace);
         if (!maybeFunction.isPresent()) {
+            CompilerDirectives.transferToInterpreter();
             throw new GrCUDAException("function '" + functionName +
                             "' not found in namespace '" + namespace + "'", this);
         }
@@ -73,6 +75,7 @@ public abstract class CallNode extends ExpressionNode {
         try {
             return interop.execute(function, argumentValues);
         } catch (ArityException | UnsupportedTypeException | UnsupportedMessageException e) {
+            CompilerDirectives.transferToInterpreter();
             throw new RuntimeException((e));
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/parser/ParserAntlr.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/parser/ParserAntlr.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +30,7 @@ package com.nvidia.grcuda.parser;
 
 import com.nvidia.grcuda.nodes.ExpressionNode;
 import com.nvidia.grcuda.parser.antlr.GrCUDAParser;
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.source.Source;
 
 public final class ParserAntlr {
@@ -38,6 +40,7 @@ public final class ParserAntlr {
 
     @SuppressWarnings("static-method")
     public ExpressionNode parse(Source source) throws ParserException {
+        CompilerAsserts.neverPartOfCompilation();
         return GrCUDAParser.parseCUDA(source);
     }
 }


### PR DESCRIPTION
These changes are enough to allow creating a native image with support for grCUDA.
Unfortunately, it's not quite obvious how to build and use a polyglot image:
```
bin/gu rebuild-images libpolyglot -cp <path-to>/grcuda.jar
```
will enable grCUDA in `bin/node --polyglot.

```
bin/gu rebuild-images polyglot -cp <path-to>/grcuda.jar
```
will enable grCUDA in `bin/js --polyglot.