### PR TITLE
Bug fix for MultiDimDeviceArray objects passed as kernel arguments

### DIFF
--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/MultiDimDeviceArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/MultiDimDeviceArray.java
@@ -167,10 +167,10 @@ public class MultiDimDeviceArray implements TruffleObject {
 
     @Override
     public String toString() {
-        return "DeviceArray(elementType=" + elementType +
+        return "MultiDimDeviceArray(elementType=" + elementType +
                         ", dims=" + Arrays.toString(elementsPerDimension) +
                         ", Elements=" + totalElementCount +
-                        ", size=" + getSizeBytes() + " bytes, " +
+                        ", size=" + getSizeBytes() + " bytes" +
                         ", nativeView=" + nativeView + ')';
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Kernel.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Kernel.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import com.nvidia.grcuda.DeviceArray;
 import com.nvidia.grcuda.DeviceArray.MemberSet;
+import com.nvidia.grcuda.MultiDimDeviceArray;
 import com.nvidia.grcuda.gpu.UnsafeHelper.MemoryObject;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.Fallback;
@@ -126,6 +127,11 @@ public final class Kernel implements TruffleObject {
                     case POINTER:
                         if (args[argIdx] instanceof DeviceArray) {
                             DeviceArray deviceArray = (DeviceArray) args[argIdx];
+                            UnsafeHelper.PointerObject pointer = UnsafeHelper.createPointerObject();
+                            pointer.setValueOfPointer(deviceArray.getPointer());
+                            kernelArgs.setArgument(argIdx, pointer);
+                        } else if (args[argIdx] instanceof MultiDimDeviceArray) {
+                            MultiDimDeviceArray deviceArray = (MultiDimDeviceArray) args[argIdx];
                             UnsafeHelper.PointerObject pointer = UnsafeHelper.createPointerObject();
                             pointer.setValueOfPointer(deviceArray.getPointer());
                             kernelArgs.setArgument(argIdx, pointer);


### PR DESCRIPTION
- Fixes issue #10  
- Adds test case in `MultiDimDeviceArrayTest` so that similar problem will be caught by the unit tests.
- Fixes incorrect `toString()` value for `MultiDimDeviceArray`