### PR TITLE
Make devices and their properties accessible through TruffleObjects

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -263,6 +263,157 @@ buildkernel(
 
 See description in the [polyglot kernel launch](docs/launchkernel.md) documentation for details.
 
+### getdevices() and getdevice() Functions
+
+The `get_devices()` functions returns an array that contains all visible
+CUDA devices. `get_device(k)` returns the `k` visible device, with
+`k` ranging from 0 to the number of visible devices - 1.
+
+```text
+devices = getdevices()
+device = getdevice(deviceOrdinal)
+```
+
+`deviceOrdinal`: integer `k` that for the kth device, `k` from 0 to
+the number of visible devices
+(see [cudaGetDevice](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html))
+
+Both functions return `Devices` objects which have the following members:
+
+Attribute `id`: the device ID (ordinal)
+
+Attribute `properties`: property objects containing device attributes
+returned by the CUDA runtime `cudaDeviceGetAttributeGet()`,
+`cudaMemgetInfo()` and `cuDeviceGetName()`.
+
+Method `isCurrent()`: method returns true iff `id` is the device
+on which the currently active host thread executes device code.
+
+Method `setCurrent()`: method sets `id` as the device the
+currently active host thread should execute device code.
+
+**Example:**
+
+```Python
+devices = polyglot.eval(language='grcuda', 'getdevices()')
+device0 = polyglot.eval(language='grcuda', 'getdevice(0)')
+# identical to device0 = devices[0]
+
+for device in devices:
+    print('{}: {}, {} multiprocessors'.format(device.id,
+       device.property.deviceName,
+       device.property.multiProcessorCount))
+# example output
+# 0: TITAN V, 80 multiprocessors
+# 1: Quadro GP100, 56 multiprocessors
+device0.setCurrent()
+print(device0.isCurrent())  # true
+```
+
+Table: Device Properties Names (see also
+[CUDA Runtime Documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html))
+| Property Name
+|-------------------------------------------|
+| `asyncEngineCount`                        |
+| `canFlushRemoteWrites`                    |
+| `canMapHostMemory`                        |
+| `canUseHostPointerForRegisteredMem`       |
+| `clockRate`                               |
+| `computeCapabilityMajor`                  |
+| `computeCapabilityMinor`                  |
+| `computeMode`                             |
+| `computePreemptionSupported`              |
+| `concurrentKernels`                       |
+| `concurrentManagedAccess`                 |
+| `cooperativeLaunch`                       |
+| `cooperativeMultiDeviceLaunch`            |
+| `deviceName`                              |
+| `directManagedMemAccessFromHost`          |
+| `eccEnabled`                              |
+| `freeDeviceMemory`                        |
+| `globalL1CacheSupported`                  |
+| `globalMemoryBusWidth`                    |
+| `gpuOverlap`                              |
+| `hostNativeAtomicSupported`               |
+| `hostRegisterSupported`                   |
+| `integrated`                              |
+| `isMultiGpuBoard`                         |
+| `kernelExecTimeout`                       |
+| `l2CacheSize`                             |
+| `localL1CacheSupported`                   |
+| `managedMemory`                           |
+| `maxBlockDimX`                            |
+| `maxBlockDimY`                            |
+| `maxBlockDimZ`                            |
+| `maxGridDimX`                             |
+| `maxGridDimY`                             |
+| `maxGridDimZ`                             |
+| `maxPitch`                                |
+| `maxRegistersPerBlock`                    |
+| `maxRegistersPerMultiprocessor`           |
+| `maxSharedMemoryPerBlock`                 |
+| `maxSharedMemoryPerBlockOptin`            |
+| `maxSharedMemoryPerMultiprocessor`        |
+| `maxSurface1DLayeredLayers`               |
+| `maxSurface1DWidth`                       |
+| `maxSurface2DHeight`                      |
+| `maxSurface2DLayeredHeight`               |
+| `maxSurface2DLayeredLayers`               |
+| `maxSurface2DLayeredWidth`                |
+| `maxSurface2DWidth`                       |
+| `maxSurface3DDepth`                       |
+| `maxSurface3DHeight`                      |
+| `maxSurface3DWidth`                       |
+| `maxSurfaceCubemapLayeredLayers`          |
+| `maxSurfaceCubemapLayeredWidth`           |
+| `maxSurfaceCubemapWidth`                  |
+| `maxTexture1DLayeredLayers`               |
+| `maxTexture1DLayeredWidth`                |
+| `maxTexture1DLinearWidth`                 |
+| `maxTexture1DMipmappedWidth`              |
+| `maxTexture1DWidth`                       |
+| `maxTexture2DGatherHeight`                |
+| `maxTexture2DGatherWidth`                 |
+| `maxTexture2DHeight`                      |
+| `maxTexture2DLayeredHeight`               |
+| `maxTexture2DLayeredLayers`               |
+| `maxTexture2DLayeredWidth`                |
+| `maxTexture2DLinearHeight`                |
+| `maxTexture2DLinearPitch`                 |
+| `maxTexture2DLinearWidth`                 |
+| `maxTexture2DMipmappedHeight`             |
+| `maxTexture2DMipmappedWidth`              |
+| `maxTexture2DWidth`                       |
+| `maxTexture3DDepth`                       |
+| `maxTexture3DDepthAlt`                    |
+| `maxTexture3DHeight`                      |
+| `maxTexture3DHeightAlt`                   |
+| `maxTexture3DWidth`                       |
+| `maxTexture3DWidthAlt`                    |
+| `maxTextureCubemapLayeredLayers`          |
+| `maxTextureCubemapLayeredWidth`           |
+| `maxTextureCubemapWidth`                  |
+| `maxThreadsPerBlock`                      |
+| `maxThreadsPerMultiProcessor`             |
+| `memoryClockRate`                         |
+| `multiGpuBoardGroupID`                    |
+| `multiProcessorCount`                     |
+| `pageableMemoryAccess`                    |
+| `pageableMemoryAccessUsesHostPageTables`  |
+| `pciBusId`                                |
+| `pciDeviceId`                             |
+| `pciDomainId`                             |
+| `singleToDoublePrecisionPerfRatio`        |
+| `streamPrioritiesSupported`               |
+| `surfaceAlignment`                        |
+| `tccDriver`                               |
+| `textureAlignment`                        |
+| `texturePitchAlignment`                   |
+| `totalConstantMemory`                     |
+| `totalDeviceMemory`                       |
+| `unifiedAddressing`                       |
+| `warpSize`                                |
+
 ### DeviceArray Constructor Function
 
 In addition to arrays expression, device arrays can also be

--- a/docs/language.md
+++ b/docs/language.md
@@ -265,8 +265,8 @@ See description in the [polyglot kernel launch](docs/launchkernel.md) documentat
 
 ### getdevices() and getdevice() Functions
 
-The `get_devices()` functions returns an array that contains all visible
-CUDA devices. `get_device(k)` returns the `k` visible device, with
+The `getdevices()` functions returns an array that contains all visible
+CUDA devices. `getdevice(k)` returns the `k` visible device, with
 `k` ranging from 0 to the number of visible devices - 1.
 
 ```text

--- a/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/DeviceTest.java
+++ b/projects/com.nvidia.grcuda.test/src/com/nvidia/grcuda/test/DeviceTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nvidia.grcuda.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.junit.Test;
+
+public class DeviceTest {
+
+    @Test
+    public void testDeviceCount() {
+        try (Context ctx = Context.newBuilder().allowAllAccess(true).build()) {
+            Value deviceCount = ctx.eval("grcuda", "cudaGetDeviceCount()");
+            assertTrue(deviceCount.isNumber());
+            assertTrue(deviceCount.asInt() > 0);
+        }
+    }
+
+    @Test
+    public void testGetDevicesLengthsMatchesDeviceCount() {
+        try (Context ctx = Context.newBuilder().allowAllAccess(true).build()) {
+            Value deviceCount = ctx.eval("grcuda", "cudaGetDeviceCount()");
+            assertTrue(deviceCount.isNumber());
+            assertTrue(deviceCount.asInt() > 0);
+            Value devices = ctx.eval("grcuda", "getdevices()");
+            assertEquals(deviceCount.asInt(), devices.getArraySize());
+        }
+    }
+
+    @Test
+    public void testGetDevicesMatchesAllGetDevice() {
+        try (Context ctx = Context.newBuilder().allowAllAccess(true).build()) {
+            Value devices = ctx.eval("grcuda", "getdevices()");
+            Value getDevice = ctx.eval("grcuda", "getdevice");
+            for (int i = 0; i < devices.getArraySize(); ++i) {
+                Value deviceFromArray = devices.getArrayElement(i);
+                Value deviceFromFunction = getDevice.execute(i);
+                assertEquals(i, deviceFromArray.getMember("id").asInt());
+                assertEquals(i, deviceFromFunction.getMember("id").asInt());
+            }
+        }
+    }
+
+    @Test
+    public void testCanReadSomeDeviceProperties() {
+        try (Context ctx = Context.newBuilder().allowAllAccess(true).build()) {
+            Value devices = ctx.eval("grcuda", "getdevices()");
+            for (int i = 0; i < devices.getArraySize(); ++i) {
+                Value device = devices.getArrayElement(i);
+                Value prop = device.getMember("properties");
+                // Sanity tests on some of the properties
+                // device name is a non-zero string
+                assertTrue(prop.getMember("deviceName").asString().length() > 0);
+
+                // compute capability is at least compute Kepler (3.0)
+                assertTrue(prop.getMember("computeCapabilityMajor").asInt() >= 3);
+
+                // there is at least one multiprocessors
+                assertTrue(prop.getMember("multiProcessorCount").asInt() > 0);
+
+                // there is some device memory
+                assertTrue(prop.getMember("totalDeviceMemory").asLong() > 0L);
+            }
+        }
+    }
+
+    @Test
+    public void testCanSelectDevice() {
+        try (Context ctx = Context.newBuilder().allowAllAccess(true).build()) {
+            Value devices = ctx.eval("grcuda", "getdevices()");
+            if (devices.getArraySize() > 1) {
+                Value firstDevice = devices.getArrayElement(0);
+                Value secondDevice = devices.getArrayElement(1);
+                secondDevice.invokeMember("setCurrent");
+                assertFalse(firstDevice.invokeMember("isCurrent").asBoolean());
+                assertTrue(secondDevice.invokeMember("isCurrent").asBoolean());
+
+                firstDevice.invokeMember("setCurrent");
+                assertTrue(firstDevice.invokeMember("isCurrent").asBoolean());
+                assertFalse(secondDevice.invokeMember("isCurrent").asBoolean());
+            } else {
+                // only one device available
+                Value device = devices.getArrayElement(0);
+                device.invokeMember("setCurrent");
+                assertTrue(device.invokeMember("isCurrent").asBoolean());
+            }
+        }
+    }
+
+    @Test
+    public void testDeviceMemoryAllocationReducesReportedFreeMemory() {
+        try (Context ctx = Context.newBuilder().allowAllAccess(true).build()) {
+            Value device = ctx.eval("grcuda", "getdevice(0)");
+            Value props = device.getMember("properties");
+            device.invokeMember("setCurrent");
+            long totalMemoryBefore = props.getMember("totalDeviceMemory").asLong();
+            long freeMemoryBefore = props.getMember("freeDeviceMemory").asLong();
+            assertTrue(freeMemoryBefore <= totalMemoryBefore);
+
+            // allocate memory on device (unmanaged)
+            long arraySizeBytes = freeMemoryBefore / 3;
+            Value cudaMalloc = ctx.eval("grcuda", "cudaMalloc");
+            Value cudaFree = ctx.eval("grcuda", "cudaFree");
+            Value gpuPointer = null;
+            try {
+                gpuPointer = cudaMalloc.execute(arraySizeBytes);
+                // After allocation total memory must be the same as before but
+                // the free memory must be lower by at least the amount of allocated bytes.
+                long totalMemoryAfter = props.getMember("totalDeviceMemory").asLong();
+                long freeMemoryAfter = props.getMember("freeDeviceMemory").asLong();
+                assertEquals(totalMemoryBefore, totalMemoryAfter);
+                assertTrue(freeMemoryAfter <= (freeMemoryBefore - arraySizeBytes));
+            } finally {
+                if (gpuPointer != null) {
+                    cudaFree.execute(gpuPointer);
+                }
+            }
+        }
+    }
+
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/DeviceArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/DeviceArray.java
@@ -244,44 +244,46 @@ public final class DeviceArray implements TruffleObject {
 
     @ExportMessage
     @SuppressWarnings("static-method")
-    boolean isMemberReadable(String member,
-                    @Shared("member") @Cached("createIdentityProfile()") ValueProfile memberProfile) {
-        return POINTER.equals(memberProfile.profile(member)) || COPY_FROM.equals(memberProfile.profile(member)) || COPY_TO.equals(memberProfile.profile(member));
+    boolean isMemberReadable(String memberName,
+                    @Shared("memberName") @Cached("createIdentityProfile()") ValueProfile memberProfile) {
+        return POINTER.equals(memberProfile.profile(memberName)) ||
+                        COPY_FROM.equals(memberProfile.profile(memberName)) ||
+                        COPY_TO.equals(memberProfile.profile(memberName));
     }
 
     @ExportMessage
-    Object readMember(String member,
-                    @Shared("member") @Cached("createIdentityProfile()") ValueProfile memberProfile) throws UnknownIdentifierException {
-        if (!isMemberReadable(member, memberProfile)) {
+    Object readMember(String memberName,
+                    @Shared("memberName") @Cached("createIdentityProfile()") ValueProfile memberProfile) throws UnknownIdentifierException {
+        if (!isMemberReadable(memberName, memberProfile)) {
             CompilerDirectives.transferToInterpreter();
-            throw UnknownIdentifierException.create(member);
+            throw UnknownIdentifierException.create(memberName);
         }
-        if (POINTER.equals(member)) {
+        if (POINTER.equals(memberName)) {
             return getPointer();
         }
-        if (COPY_FROM.equals(member)) {
+        if (COPY_FROM.equals(memberName)) {
             return new DeviceArrayCopyFunction(this, DeviceArrayCopyFunction.CopyDirection.FROM_POINTER);
         }
-        if (COPY_TO.equals(member)) {
+        if (COPY_TO.equals(memberName)) {
             return new DeviceArrayCopyFunction(this, DeviceArrayCopyFunction.CopyDirection.TO_POINTER);
         }
         CompilerDirectives.transferToInterpreter();
-        throw UnknownIdentifierException.create(member);
+        throw UnknownIdentifierException.create(memberName);
     }
 
     @ExportMessage
     @SuppressWarnings("static-method")
-    boolean isMemberInvocable(String member) {
-        return COPY_FROM.equals(member) || COPY_TO.equals(member);
+    boolean isMemberInvocable(String memberName) {
+        return COPY_FROM.equals(memberName) || COPY_TO.equals(memberName);
     }
 
     @ExportMessage
-    Object invokeMember(String member,
+    Object invokeMember(String memberName,
                     Object[] arguments,
                     @CachedLibrary(limit = "1") InteropLibrary interopRead,
                     @CachedLibrary(limit = "1") InteropLibrary interopExecute)
                     throws UnsupportedTypeException, ArityException, UnsupportedMessageException, UnknownIdentifierException {
-        return interopExecute.execute(interopRead.readMember(this, member), arguments);
+        return interopExecute.execute(interopRead.readMember(this, memberName), arguments);
     }
 
     @ExportMessage

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/DeviceArray.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/DeviceArray.java
@@ -246,9 +246,8 @@ public final class DeviceArray implements TruffleObject {
     @SuppressWarnings("static-method")
     boolean isMemberReadable(String memberName,
                     @Shared("memberName") @Cached("createIdentityProfile()") ValueProfile memberProfile) {
-        return POINTER.equals(memberProfile.profile(memberName)) ||
-                        COPY_FROM.equals(memberProfile.profile(memberName)) ||
-                        COPY_TO.equals(memberProfile.profile(memberName));
+        String name = memberProfile.profile(memberName);
+        return POINTER.equals(name) || COPY_FROM.equals(name) || COPY_TO.equals(name);
     }
 
     @ExportMessage

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -34,6 +34,7 @@ import com.nvidia.grcuda.functions.BindKernelFunction;
 import com.nvidia.grcuda.functions.BuildKernelFunction;
 import com.nvidia.grcuda.functions.DeviceArrayFunction;
 import com.nvidia.grcuda.functions.FunctionTable;
+import com.nvidia.grcuda.functions.GetDeviceFunction;
 import com.nvidia.grcuda.gpu.CUDARuntime;
 import com.oracle.truffle.api.TruffleLanguage.Env;
 
@@ -56,6 +57,7 @@ public final class GrCUDAContext {
         functionTable.registerFunction(new DeviceArrayFunction(cudaRuntime));
         functionTable.registerFunction(new BindKernelFunction(cudaRuntime));
         functionTable.registerFunction(new BuildKernelFunction(cudaRuntime));
+        functionTable.registerFunction(new GetDeviceFunction(cudaRuntime));
     }
 
     public Env getEnv() {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAContext.java
@@ -35,6 +35,7 @@ import com.nvidia.grcuda.functions.BuildKernelFunction;
 import com.nvidia.grcuda.functions.DeviceArrayFunction;
 import com.nvidia.grcuda.functions.FunctionTable;
 import com.nvidia.grcuda.functions.GetDeviceFunction;
+import com.nvidia.grcuda.functions.GetDevicesFunction;
 import com.nvidia.grcuda.gpu.CUDARuntime;
 import com.oracle.truffle.api.TruffleLanguage.Env;
 
@@ -57,6 +58,7 @@ public final class GrCUDAContext {
         functionTable.registerFunction(new DeviceArrayFunction(cudaRuntime));
         functionTable.registerFunction(new BindKernelFunction(cudaRuntime));
         functionTable.registerFunction(new BuildKernelFunction(cudaRuntime));
+        functionTable.registerFunction(new GetDevicesFunction(cudaRuntime));
         functionTable.registerFunction(new GetDeviceFunction(cudaRuntime));
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/NoneValue.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/NoneValue.java
@@ -31,6 +31,7 @@ package com.nvidia.grcuda;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
 
 /**
  * None is a singleton object that will always returned of a function or a member returns `void`.
@@ -61,5 +62,10 @@ public class NoneValue implements TruffleObject {
     @Override
     public boolean equals(Object other) {
         return other instanceof NoneValue;
+    }
+
+    @ExportMessage
+    public boolean isNull() {
+        return true;
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/NoneValue.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/NoneValue.java
@@ -26,28 +26,40 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nvidia.grcuda.functions;
+package com.nvidia.grcuda;
 
-import com.nvidia.grcuda.gpu.CUDARuntime;
-import com.nvidia.grcuda.gpu.Device;
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.interop.ArityException;
-import com.oracle.truffle.api.interop.UnsupportedTypeException;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.library.ExportLibrary;
 
-public class GetDeviceFunction extends Function {
+/**
+ * None is a singleton object that will always returned of a function or a member returns `void`.
+ *
+ * This is to satisfy the post-condition in the Truffle call contract for invokeMember and execute,
+ * which states the the result type must be either a boxed primitive type or a TruffleObject.
+ *
+ */
+@ExportLibrary(InteropLibrary.class)
+public class NoneValue implements TruffleObject {
 
-    private final CUDARuntime runtime;
+    private static final NoneValue singleton = new NoneValue();
 
-    public GetDeviceFunction(CUDARuntime runtime) {
-        super("getdevice", "");
-        this.runtime = runtime;
+    public static NoneValue get() {
+        return singleton;
     }
 
     @Override
-    @TruffleBoundary
-    public Object call(Object[] arguments) throws UnsupportedTypeException, ArityException {
-        checkArgumentLength(arguments, 1);
-        int deviceId = expectPositiveInt(arguments[0]);
-        return new Device(deviceId, runtime);
+    public String toString() {
+        return "NoneValue";
+    }
+
+    @Override
+    public int hashCode() {
+        return 123456789;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof NoneValue;
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/Function.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/Function.java
@@ -91,6 +91,14 @@ public abstract class Function implements TruffleObject {
         return expectLong(number, "expected long number argument");
     }
 
+    protected static int expectPositiveInt(Object number) throws UnsupportedTypeException {
+        int value = expectInt(number);
+        if (value < 0) {
+            throw UnsupportedTypeException.create(new Object[]{number}, "expected positive int number argument");
+        }
+        return value;
+    }
+
     protected static long expectPositiveLong(Object number) throws UnsupportedTypeException {
         long value = expectLong(number);
         if (value < 0) {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetDeviceFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetDeviceFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nvidia.grcuda.functions;
+
+import com.nvidia.grcuda.gpu.CUDARuntime;
+import com.nvidia.grcuda.gpu.Device;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.interop.ArityException;
+import com.oracle.truffle.api.interop.UnsupportedTypeException;
+
+public class GetDeviceFunction extends Function {
+
+    private final CUDARuntime runtime;
+
+    public GetDeviceFunction(CUDARuntime runtime) {
+        super("getDevice", "");
+        this.runtime = runtime;
+    }
+
+    @Override
+    @TruffleBoundary
+    public Object call(Object[] arguments) throws UnsupportedTypeException, ArityException {
+        checkArgumentLength(arguments, 1);
+        int deviceId = expectPositiveInt(arguments[0]);
+        return new Device(deviceId, runtime);
+    }
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetDevicesFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/GetDevicesFunction.java
@@ -29,25 +29,24 @@
 package com.nvidia.grcuda.functions;
 
 import com.nvidia.grcuda.gpu.CUDARuntime;
-import com.nvidia.grcuda.gpu.Device;
+import com.nvidia.grcuda.gpu.DeviceList;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.UnsupportedTypeException;
 
-public class GetDeviceFunction extends Function {
-
+public class GetDevicesFunction extends Function {
     private final CUDARuntime runtime;
 
-    public GetDeviceFunction(CUDARuntime runtime) {
-        super("getdevice", "");
+    public GetDevicesFunction(CUDARuntime runtime) {
+        super("getdevices", "");
         this.runtime = runtime;
     }
 
     @Override
     @TruffleBoundary
     public Object call(Object[] arguments) throws UnsupportedTypeException, ArityException {
-        checkArgumentLength(arguments, 1);
-        int deviceId = expectPositiveInt(arguments[0]);
-        return new Device(deviceId, runtime);
+        checkArgumentLength(arguments, 0);
+        int numDevices = runtime.cudaGetDeviceCount();
+        return new DeviceList(numDevices, runtime);
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
@@ -36,6 +36,7 @@ import com.nvidia.grcuda.GrCUDAContext;
 import com.nvidia.grcuda.functions.CUDAFunction;
 import com.nvidia.grcuda.functions.CUDAFunctionFactory;
 import com.nvidia.grcuda.functions.FunctionTable;
+import com.nvidia.grcuda.gpu.UnsafeHelper.Integer32Object;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.TruffleLanguage.Env;
@@ -203,6 +204,35 @@ public final class CUDARuntime {
     }
 
     @TruffleBoundary
+    public int cudaGetDevice() {
+        try {
+            Object callable = getSymbol(CUDARuntimeFunction.CUDA_GETDEVICE);
+            try (Integer32Object deviceId = UnsafeHelper.createInteger32Object()) {
+                Object result = INTEROP.execute(callable, deviceId.getAddress());
+                checkCUDAReturnCode(result, "cudaGetDevice");
+                return deviceId.getValue();
+            }
+
+        } catch (InteropException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @TruffleBoundary
+    public int cudaDeviceGetAttribute(CUDADeviceAttribute attribute, int deviceId) {
+        try {
+            Object callable = getSymbol(CUDARuntimeFunction.CUDA_DEVICEGETATTRIBUTE);
+            try (Integer32Object value = UnsafeHelper.createInteger32Object()) {
+                Object result = INTEROP.execute(callable, value.getAddress(), attribute.getAttributeCode(), deviceId);
+                checkCUDAReturnCode(result, "cudaDeviceGetAttribute");
+                return value.getValue();
+            }
+        } catch (InteropException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @TruffleBoundary
     public String cudaGetErrorString(int errorCode) {
         try {
             Object callable = getSymbol(CUDARuntimeFunction.CUDA_GETERRORSTRING);
@@ -272,19 +302,21 @@ public final class CUDARuntime {
     }
 
     public enum CUDARuntimeFunction {
-        CUDA_GETDEVICECOUNT(new CUDAFunctionFactory("cudaGetDeviceCount", "", "(pointer): sint32") {
+        CUDA_DEVICEGETATTRIBUTE(new CUDAFunctionFactory("cudaDeviceGetAttribute", "", "(pointer, sint32, sint32): sint32") {
             @Override
             public CUDAFunction makeFunction(CUDARuntime cudaRuntime) {
                 return new CUDAFunction(this) {
                     @Override
                     @TruffleBoundary
-                    public Object call(Object[] args) throws ArityException {
-                        checkArgumentLength(args, 0);
-                        try (UnsafeHelper.Integer32Object deviceCount = UnsafeHelper.createInteger32Object()) {
-                            Object callable = cudaRuntime.getSymbol(CUDARuntimeFunction.CUDA_GETDEVICECOUNT);
-                            Object result = INTEROP.execute(callable, deviceCount.getAddress());
+                    public Object call(Object[] args) throws ArityException, UnsupportedTypeException {
+                        checkArgumentLength(args, 2);
+                        int attributeCode = expectInt(args[0]);
+                        int deviceId = expectInt(args[1]);
+                        try (UnsafeHelper.Integer32Object value = UnsafeHelper.createInteger32Object()) {
+                            Object callable = cudaRuntime.getSymbol(CUDARuntimeFunction.CUDA_DEVICEGETATTRIBUTE);
+                            Object result = INTEROP.execute(callable, value.getAddress(), attributeCode, deviceId);
                             cudaRuntime.checkCUDAReturnCode(result, getName());
-                            return deviceCount.getValue();
+                            return value.getValue();
                         } catch (InteropException e) {
                             throw new RuntimeException(e);
                         }
@@ -292,7 +324,6 @@ public final class CUDARuntime {
                 };
             }
         }),
-
         CUDA_DEVICERESET(new CUDAFunctionFactory("cudaDeviceReset", "", "(): sint32") {
             @Override
             public CUDAFunction makeFunction(CUDARuntime cudaRuntime) {
@@ -357,6 +388,46 @@ public final class CUDARuntime {
                             Object result = INTEROP.execute(callable, addr);
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                             return null;
+                        } catch (InteropException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                };
+            }
+        }),
+        CUDA_GETDEVICE(new CUDAFunctionFactory("cudaGetDevice", "", "(pointer): sint32") {
+            @Override
+            public CUDAFunction makeFunction(CUDARuntime cudaRuntime) {
+                return new CUDAFunction(this) {
+                    @Override
+                    @TruffleBoundary
+                    public Object call(Object[] args) throws ArityException {
+                        checkArgumentLength(args, 0);
+                        try (UnsafeHelper.Integer32Object deviceId = UnsafeHelper.createInteger32Object()) {
+                            Object callable = cudaRuntime.getSymbol(CUDARuntimeFunction.CUDA_GETDEVICE);
+                            Object result = INTEROP.execute(callable, deviceId.getAddress());
+                            cudaRuntime.checkCUDAReturnCode(result, getName());
+                            return deviceId.getValue();
+                        } catch (InteropException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                };
+            }
+        }),
+        CUDA_GETDEVICECOUNT(new CUDAFunctionFactory("cudaGetDeviceCount", "", "(pointer): sint32") {
+            @Override
+            public CUDAFunction makeFunction(CUDARuntime cudaRuntime) {
+                return new CUDAFunction(this) {
+                    @Override
+                    @TruffleBoundary
+                    public Object call(Object[] args) throws ArityException {
+                        checkArgumentLength(args, 0);
+                        try (UnsafeHelper.Integer32Object deviceCount = UnsafeHelper.createInteger32Object()) {
+                            Object callable = cudaRuntime.getSymbol(CUDARuntimeFunction.CUDA_GETDEVICECOUNT);
+                            Object result = INTEROP.execute(callable, deviceCount.getAddress());
+                            cudaRuntime.checkCUDAReturnCode(result, getName());
+                            return deviceCount.getValue();
                         } catch (InteropException e) {
                             throw new RuntimeException(e);
                         }
@@ -776,6 +847,123 @@ public final class CUDARuntime {
         }
     }
 
+    /** CUDA device attributes from driver_types.h CUDA header. */
+    public enum CUDADeviceAttribute {
+        MAX_THREADS_PER_BLOCK("maxThreadsPerBlock", 1),
+        MAX_BLOCK_DIMX("maxBlockDimX", 2),
+        MAX_BLOCK_DIMY("maxBlockDimY", 3),
+        MAX_BLOCK_DIMZ("maxBlockDimZ", 4),
+        MAX_GRID_DIMX("maxGridDimX", 5),
+        MAX_GRID_DIMY("maxGridDimY", 6),
+        MAX_GRID_DIMZ("maxGridDimZ", 7),
+        MAX_SHARED_MEMORY_PER_BLOCK("maxSharedMemoryPerBlock", 8),
+        TOTAL_CONSTANT_MEMORY("totalConstantMemory", 9),
+        WARPSIZE("warpSize", 10),
+        MAX_PITCH("maxPitch", 11),
+        MAX_REGISTERS_PER_BLOCK("maxRegistersPerBlock", 12),
+        CLOCK_RATE("clockRate", 13),
+        TEXTURE_ALIGNMENT("textureAlignment", 14),
+        GPU_OVERLAP("gpuOverlap", 15),
+        MULTI_PROCESSOR_COUNT("multiProcessorCount", 16),
+        KERNEL_EXEC_TIMEOUT("kernelExecTimeout", 17),
+        INTEGRATED("integrated", 18),
+        CAN_MAP_HOST_MEMORY("canMapHostMemory", 19),
+        COMPUTE_MODE("computeMode", 20),
+        MAX_TEXTURE1D_WIDTH("maxTexture1DWidth", 21),
+        MAX_TEXTURE2D_WIDTH("maxTexture2DWidth", 22),
+        MAX_TEXTURE2D_HEIGHT("maxTexture2DHeight", 23),
+        MAX_TEXTURE3D_WIDTH("maxTexture3DWidth", 24),
+        MAX_TEXTURE3D_HEIGHT("maxTexture3DHeight", 25),
+        MAX_TEXTURE3D_DEPTH("maxTexture3DDepth", 26),
+        MAX_TEXTURE2D_LAYERED_WIDTH("maxTexture2DLayeredWidth", 27),
+        MAX_TEXTURE2D_LAYERED_HEIGHT("maxTexture2DLayeredHeight", 28),
+        MAX_TEXTURE2D_LAYERED_LAYERS("maxTexture2DLayeredLayers", 29),
+        SURFACE_ALIGNMENT("surfaceAlignment", 30),
+        CONCURRENT_KERNELS("concurrentKernels", 31),
+        ECC_ENABLED("eccEnabled", 32),
+        PCI_BUS_ID("pciBusId", 33),
+        PCI_DEVICE_ID("pciDeviceId", 34),
+        TCC_DRIVER("tccDriver", 35),
+        MEMORY_CLOCK_RATE("memoryClockRate", 36),
+        GLOBAL_MEMORY_BUS_WIDTH("globalMemoryBusWidth", 37),
+        L2_CACHE_SIZE("l2CacheSize", 38),
+        MAX_THREADS_PER_MULTIPROCESSOR("maxThreadsPerMultiProcessor", 39),
+        ASYNC_ENGINE_COUNT("asyncEngineCount", 40),
+        UNIFIED_ADDRESSING("unifiedAddressing", 41),
+        MAX_TEXTURE1D_LAYERED_WIDTH("maxTexture1DLayeredWidth", 42),
+        MAX_TEXTURE1D_LAYERED_LAYERS("maxTexture1DLayeredLayers", 43),
+        MAX_TEXTURE2D_GATHER_WIDTH("maxTexture2DGatherWidth", 45),
+        MAX_TEXTURE2D_GATHER_HEIGHT("maxTexture2DGatherHeight", 46),
+        MAX_TEXTURE3D_WIDTH_ALT("maxTexture3DWidthAlt", 47),
+        MAX_TEXTURE3D_HEIGHT_ALT("maxTexture3DHeightAlt", 48),
+        MAX_TEXTURE3D_DEPTH_ALT("maxTexture3DDepthAlt", 49),
+        PCI_DOMAIN_ID("pciDomainId", 50),
+        TEXTURE_PITCH_ALIGNMENT("texturePitchAlignment", 51),
+        MAX_TEXTURE_CUBEMAP_WIDTH("maxTextureCubemapWidth", 52),
+        MAX_TEXTURE_CUBEMAP_LAYERED_WIDTH("maxTextureCubemapLayeredWidth", 53),
+        MAX_TEXTURE_CUBEMAP_LAYERED_LAYERS("maxTextureCubemapLayeredLayers", 54),
+        MAX_SURFACE1D_WIDTH("maxSurface1DWidth", 55),
+        MAX_SURFACE2D_WIDTH("maxSurface2DWidth", 56),
+        MAX_SURFACE2D_HEIGHT("maxSurface2DHeight", 57),
+        MAX_SURFACE3D_WIDTH("maxSurface3DWidth", 58),
+        MAX_SURFACE3D_HEIGHT("maxSurface3DHeight", 59),
+        MAX_SURFACE3D_DEPTH("maxSurface3DDepth", 60),
+        MAX_SURFACE1D_LAYERED_WIDTH("maxSurface1DLayeredWidth", 61),
+        MAX_SURFACE1D_LAYERED_LAYERS("maxSurface1DLayeredLayers", 62),
+        MAX_SURFACE2D_LAYERED_WIDTH("maxSurface2DLayeredWidth", 63),
+        MAX_SURFACE2D_LAYERED_HEIGHT("maxSurface2DLayeredHeight", 64),
+        MAX_SURFACE2D_LAYERED_LAYERS("maxSurface2DLayeredLayers", 65),
+        MAX_SURFACE_CUBEMAP_WIDTH("maxSurfaceCubemapWidth", 66),
+        MAX_SURFACE_CUBEMAP_LAYERED_WIDTH("maxSurfaceCubemapLayeredWidth", 67),
+        MAX_SURFACE_CUBEMAP_LAYERED_LAYERS("maxSurfaceCubemapLayeredLayers", 68),
+        MAX_TEXTURE1D_LINEAR_WIDTH("maxTexture1DLinearWidth", 69),
+        MAX_TEXTURE2D_LINEAR_WIDTH("maxTexture2DLinearWidth", 70),
+        MAX_TEXTURE2D_LINEAR_HEIGHT("maxTexture2DLinearHeight", 71),
+        MAX_TEXTURE2D_LINEAR_PITCH("maxTexture2DLinearPitch", 72),
+        MAX_TEXTURE2D_MIPMAPPED_WIDTH("maxTexture2DMipmappedWidth", 73),
+        MAX_TEXTURE2D_MIPMAPPED_HEIGHT("maxTexture2DMipmappedHeight", 74),
+        COMPUTE_CAPABILITY_MAJOR("computeCapabilityMajor", 75),
+        COMPUTE_CAPABILITY_MINOR("computeCapabilityMinor", 76),
+        MAX_TEXTURE1D_MIPMAPPED_WIDTH("maxTexture1DMipmappedWidth", 77),
+        STREAM_PRIORITIES_SUPPORTED("streamPrioritiesSupported", 78),
+        GLOBAL_L1_CACHE_SUPPORTED("globalL1CacheSupported", 79),
+        LOCAL_L1_CACHE_SUPPORTED("localL1CacheSupported", 80),
+        MAX_SHARED_MEMORY_PER_MULTIPROCESSOR("maxSharedMemoryPerMultiprocessor", 81),
+        MAX_REGISTERS_PER_MULTIPROCESSOR("maxRegistersPerMultiprocessor", 82),
+        MANAGED_MEMORY("managedMemory", 83),
+        IS_MULTI_GPU_BOARD("isMultiGpuBoard", 84),
+        MULTI_GPU_BOARD_GROUP_ID("multiGpuBoardGroupID", 85),
+        HOST_NATIVE_ATOMIC_SUPPORTED("hostNativeAtomicSupported", 86),
+        SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO("singleToDoublePrecisionPerfRatio", 87),
+        PAGEABLE_MEMORY_ACCESS("pageableMemoryAccess", 88),
+        CONCURRENT_MANAGED_ACCESS("concurrentManagedAccess", 89),
+        COMPUTE_PREEMPTION_SUPPORTED("computePreemptionSupported", 90),
+        CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM("canUseHostPointerForRegisteredMem", 91),
+        COOPERATIVE_LAUNCH("cooperativeLaunch", 95),
+        COOPERATIVE_MULTI_DEVICE_LAUNCH("cooperativeMultiDeviceLaunch", 96),
+        MAX_SHARED_MEMORY_PER_BLOCK_OPTIN("maxSharedMemoryPerBlockOptin", 97),
+        CAN_FLUSH_REMOTE_WRITES("canFlushRemoteWrites", 98),
+        HOST_REGISTER_SUPPORTED("hostRegisterSupported", 99),
+        PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES("pageableMemoryAccessUsesHostPageTables", 100),
+        DIRECT_MANAGED_MEM_ACCESS_FROM_HOST("directManagedMemAccessFromHost", 101);
+
+        final String attributeName;
+        final int attributeCode;
+
+        String getAttributeName() {
+            return attributeName;
+        }
+
+        int getAttributeCode() {
+            return attributeCode;
+        }
+
+        CUDADeviceAttribute(String name, int code) {
+            this.attributeName = name;
+            this.attributeCode = code;
+        }
+    }
+
     final class CUModule {
         final String cubinFile;
         final long module;
@@ -821,4 +1009,5 @@ public final class CUDARuntime {
             return cubinFile.hashCode();
         }
     }
+
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
@@ -175,12 +175,11 @@ public final class CUDARuntime {
             final String symbol = "cudaMemGetInfo";
             final String nfiSignature = "(pointer, pointer): sint32";
             Object callable = getSymbol(CUDA_RUNTIME_LIBRARY_NAME, symbol, nfiSignature);
-            try (Integer64Object freeBytes = UnsafeHelper.createInteger64Object()) {
-                try (Integer64Object totalBytes = UnsafeHelper.createInteger64Object()) {
-                    Object result = INTEROP.execute(callable, freeBytes.getAddress(), totalBytes.getAddress());
-                    checkCUDAReturnCode(result, symbol);
-                    return new DeviceMemoryInfo(freeBytes.getValue(), totalBytes.getValue());
-                }
+            try (Integer64Object freeBytes = UnsafeHelper.createInteger64Object();
+                            Integer64Object totalBytes = UnsafeHelper.createInteger64Object()) {
+                Object result = INTEROP.execute(callable, freeBytes.getAddress(), totalBytes.getAddress());
+                checkCUDAReturnCode(result, symbol);
+                return new DeviceMemoryInfo(freeBytes.getValue(), totalBytes.getValue());
             }
         } catch (InteropException e) {
             throw new RuntimeException(e);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Device.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Device.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nvidia.grcuda.gpu;
+
+import com.nvidia.grcuda.DeviceArray.MemberSet;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.profiles.ValueProfile;
+
+@ExportLibrary(InteropLibrary.class)
+public final class Device implements TruffleObject {
+
+    private static final String ID = "id";
+    private static final String PROPERTIES = "properties";
+    private static final MemberSet PUBLIC_MEMBERS = new MemberSet(ID, PROPERTIES);
+
+    private final int deviceId;
+    private final GPUDeviceProperties properties;
+
+    public Device(int deviceId, CUDARuntime runtime) {
+        this.deviceId = deviceId;
+        this.properties = new GPUDeviceProperties(deviceId, runtime);
+    }
+
+    public GPUDeviceProperties getProperties() {
+        return properties;
+    }
+
+    @Override
+    public String toString() {
+        return "Device(id=" + deviceId + ")";
+    }
+
+    // Implementation of Truffle API
+
+    @ExportMessage
+    @SuppressWarnings("static-method")
+    boolean hasMembers() {
+        return true;
+    }
+
+    @ExportMessage
+    @SuppressWarnings({"static-method", "unused"})
+    Object getMembers(boolean includeInternal) {
+        return PUBLIC_MEMBERS;
+    }
+
+    @ExportMessage
+    @SuppressWarnings("static-method")
+    boolean isMemberReadable(String member,
+                    @Shared("member") @Cached("createIdentityProfile()") ValueProfile memberProfile) {
+        return ID.equals(memberProfile.profile(member)) || PROPERTIES.equals(memberProfile.profile(member));
+    }
+
+    @ExportMessage
+    Object readMember(String member,
+                    @Shared("member") @Cached("createIdentityProfile()") ValueProfile memberProfile) throws UnknownIdentifierException {
+        if (!isMemberReadable(member, memberProfile)) {
+            CompilerDirectives.transferToInterpreter();
+            throw UnknownIdentifierException.create(member);
+        }
+        if (ID.equals(member)) {
+            return deviceId;
+        }
+        if (PROPERTIES.equals(member)) {
+            return properties;
+        }
+        CompilerDirectives.transferToInterpreter();
+        throw UnknownIdentifierException.create(member);
+    }
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Device.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Device.java
@@ -104,9 +104,9 @@ public final class Device implements TruffleObject {
     @SuppressWarnings("static-method")
     boolean isMemberReadable(String memberName,
                     @Shared("memberName") @Cached("createIdentityProfile()") ValueProfile memberProfile) {
-        return ID.equals(memberProfile.profile(memberName)) || PROPERTIES.equals(memberProfile.profile(memberName)) ||
-                        IS_CURRENT.equals(memberProfile.profile(memberName)) ||
-                        SET_CURRENT.equals(memberProfile.profile(memberName));
+        String name = memberProfile.profile(memberName);
+        return ID.equals(name) || PROPERTIES.equals(name) ||
+                        IS_CURRENT.equals(name) || SET_CURRENT.equals(name);
     }
 
     @ExportMessage

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/DeviceList.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/DeviceList.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nvidia.grcuda.gpu;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnsupportedMessageException;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+
+@ExportLibrary(InteropLibrary.class)
+public final class DeviceList implements TruffleObject, Iterable<Device> {
+
+    private final Device[] devices;
+
+    public DeviceList(int numDevices, CUDARuntime runtime) {
+        devices = new Device[numDevices];
+        for (int deviceOrdinal = 0; deviceOrdinal < numDevices; ++deviceOrdinal) {
+            devices[deviceOrdinal] = new Device(deviceOrdinal, runtime);
+        }
+    }
+
+    // Java API
+
+    public Iterator<Device> iterator() {
+        return new Iterator<Device>() {
+            int nextIndex = 0;
+
+            public boolean hasNext() {
+                return nextIndex < devices.length;
+            }
+
+            public Device next() {
+                if (nextIndex < devices.length) {
+                    return devices[nextIndex++];
+                } else {
+                    CompilerDirectives.transferToInterpreter();
+                    throw new NoSuchElementException();
+                }
+            }
+        };
+    }
+
+    public int size() {
+        return devices.length;
+    }
+
+    public Device getDevice(int deviceOrdinal) {
+        if ((deviceOrdinal < 0) || (deviceOrdinal >= devices.length)) {
+            CompilerDirectives.transferToInterpreter();
+            throw new IndexOutOfBoundsException();
+        }
+        return devices[deviceOrdinal];
+    }
+
+    @Override
+    public String toString() {
+        boolean notFirst = false;
+        StringBuffer buf = new StringBuffer("[");
+        for (Device device : devices) {
+            if (notFirst) {
+                buf.append(", ");
+            }
+            buf.append(device.toString());
+            notFirst = true;
+        }
+        buf.append(']');
+        return buf.toString();
+    }
+
+    // Implementation of Truffle API
+
+    @ExportMessage
+    @SuppressWarnings("static-method")
+    boolean hasMembers() {
+        return false;
+    }
+
+    @ExportMessage
+    @SuppressWarnings("static-method")
+    Object getMembers(@SuppressWarnings("unused") boolean includeInternal) {
+        return null;
+    }
+
+    @ExportMessage
+    @SuppressWarnings("static-method")
+    boolean hasArrayElements() {
+        return true;
+    }
+
+    @ExportMessage
+    public long getArraySize() {
+        return devices.length;
+    }
+
+    @ExportMessage
+    boolean isArrayElementReadable(long index) {
+        return index >= 0 && index < devices.length;
+    }
+
+    @SuppressWarnings("static-method")
+    @ExportMessage
+    boolean isArrayElementModifiable(@SuppressWarnings("unused") long index) {
+        return false;
+    }
+
+    @SuppressWarnings("static-method")
+    @ExportMessage
+    boolean isArrayElementInsertable(@SuppressWarnings("unused") long index) {
+        return false;
+    }
+
+    @ExportMessage
+    Object readArrayElement(long index) throws InvalidArrayIndexException {
+        if ((index < 0) || (index >= devices.length)) {
+            CompilerDirectives.transferToInterpreter();
+            throw InvalidArrayIndexException.create(index);
+        }
+        return devices[(int) index];
+    }
+
+    @SuppressWarnings("static-method")
+    @ExportMessage
+    void writeArrayElement(@SuppressWarnings("unused") long index, @SuppressWarnings("unused") Object value) throws UnsupportedMessageException {
+        CompilerDirectives.transferToInterpreter();
+        throw UnsupportedMessageException.create();
+    }
+}

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/GPUDeviceProperties.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/GPUDeviceProperties.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.nvidia.grcuda.gpu;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+
+import com.nvidia.grcuda.gpu.CUDARuntime.CUDADeviceAttribute;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.interop.InvalidArrayIndexException;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+
+@ExportLibrary(InteropLibrary.class)
+public final class GPUDeviceProperties implements TruffleObject {
+
+    private final CUDARuntime runtime;
+    private final int deviceId;
+
+    private static final PropertySet PROPERTY_SET = new PropertySet();
+
+    private final HashMap<String, Object> properties = new HashMap<>();
+
+    public GPUDeviceProperties(int deviceId, CUDARuntime runtime) {
+        this.deviceId = deviceId;
+        this.runtime = runtime;
+    }
+
+    @ExportMessage
+    @SuppressWarnings("static-method")
+    boolean hasMembers() {
+        return true;
+    }
+
+    @ExportMessage
+    @SuppressWarnings({"static-method", "unused"})
+    Object getMembers(boolean includeInternal) {
+        return PROPERTY_SET;
+    }
+
+    @ExportMessage
+    @SuppressWarnings("static-method")
+    boolean isMemberReadable(String member) {
+        return PROPERTY_SET.contains(member);
+    }
+
+    @ExportMessage
+    Object readMember(String member) throws UnknownIdentifierException {
+        if (!isMemberReadable(member)) {
+            CompilerDirectives.transferToInterpreter();
+            throw UnknownIdentifierException.create(member);
+        }
+        Object value = properties.get(member);
+        if (value == null) {
+            DeviceProperty prop = PROPERTY_SET.getProperty(member);
+            value = prop.getValue(deviceId, runtime);
+            properties.put(member, value);
+        }
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return "GPUDeviceProperties(deviceId=" + deviceId + ")";
+    }
+
+    @ExportLibrary(InteropLibrary.class)
+    public static final class PropertySet implements TruffleObject {
+
+        @CompilationFinal private final HashMap<String, DeviceProperty> propertyMap = new HashMap<>();
+        @CompilationFinal(dimensions = 1) private final String[] names;
+
+        PropertySet() {
+            // Add 'CUDA device attributes' properties
+            EnumSet.allOf(CUDADeviceAttribute.class).forEach(attr -> {
+                propertyMap.put(attr.getAttributeName(), new DeviceAttributeProperty(attr));
+            });
+            String[] propertyNames = new String[propertyMap.size()];
+            this.names = propertyMap.keySet().toArray(propertyNames);
+        }
+
+        private boolean contains(String name) {
+            return propertyMap.containsKey(name);
+        }
+
+        private DeviceProperty getProperty(String name) {
+            return propertyMap.get(name);
+        }
+
+        @ExportMessage
+        @SuppressWarnings("static-method")
+        public boolean hasArrayElements() {
+            return true;
+        }
+
+        @ExportMessage
+        public long getArraySize() {
+            return names.length;
+        }
+
+        @ExportMessage
+        public boolean isArrayElementReadable(long index) {
+            return index >= 0 && index < propertyMap.size();
+        }
+
+        @ExportMessage
+        public Object readArrayElement(long index) throws InvalidArrayIndexException {
+            if ((index < 0) || (index >= propertyMap.size())) {
+                CompilerDirectives.transferToInterpreter();
+                throw InvalidArrayIndexException.create(index);
+            }
+            return names[(int) index];
+        }
+    }
+
+    private interface DeviceProperty {
+
+        String getName();
+
+        Object getValue(int deviceId, CUDARuntime runtime);
+
+    }
+
+    private static class DeviceAttributeProperty implements DeviceProperty {
+
+        private final CUDADeviceAttribute attribute;
+
+        DeviceAttributeProperty(CUDADeviceAttribute attribute) {
+            this.attribute = attribute;
+        }
+
+        public String getName() {
+            return getName();
+        }
+
+        public Object getValue(int deviceId, CUDARuntime runtime) {
+            return runtime.cudaDeviceGetAttribute(attribute, deviceId);
+        }
+    }
+}


### PR DESCRIPTION
PR addresses issue #14 

Features:
- adds `get_device()` and `get_device(int)` built-in functions to grCUDA
- `get_devices()` returns a list of all visible CUDA devices as an array of `Device` 
- `get_device(int k)` returns a `Device` object for the kth device.
- `Device` objects have a `.properties` attribute, which, when accessed, lazily retrieves a given attribute from via the CUDA Runtime API.
- `Devices` have a `isCurrent()` and `setCurrent()` method to check or set the device that is currently receives commands submitted by the calling thread. 
