### PR TITLE
consistently use GrCUDAException and GrCUDAInternalException, remove deprecated parse API usages

### DIFF
--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAException.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAException.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,11 @@
  */
 package com.nvidia.grcuda;
 
+import java.util.Arrays;
+import java.util.Optional;
+
 import com.oracle.truffle.api.TruffleException;
+import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.nodes.Node;
 
 public final class GrCUDAException extends RuntimeException implements TruffleException {
@@ -43,6 +47,23 @@ public final class GrCUDAException extends RuntimeException implements TruffleEx
     public GrCUDAException(String message, Node node) {
         super(message);
         this.node = node;
+    }
+
+    public GrCUDAException(InteropException e) {
+        this(e.getMessage());
+    }
+
+    public GrCUDAException(int errorCode, String[] functionName) {
+        this("CUDA error " + errorCode + " in " + format(functionName));
+    }
+
+    public GrCUDAException(int errorCode, String message, String[] functionName) {
+        this(message + '(' + errorCode + ") in " + format(functionName));
+    }
+
+    public static String format(String... name) {
+        Optional<String> result = Arrays.asList(name).stream().reduce((a, b) -> a + "::" + b);
+        return result.orElse("<empty>");
     }
 
     @Override

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAInternalException.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDAInternalException.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,30 +26,36 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.nvidia.grcuda.gpu;
+package com.nvidia.grcuda;
 
 import com.oracle.truffle.api.TruffleException;
+import com.oracle.truffle.api.interop.InteropException;
 import com.oracle.truffle.api.nodes.Node;
 
-public class CUDAException extends RuntimeException implements TruffleException {
+public final class GrCUDAInternalException extends RuntimeException implements TruffleException {
+    private static final long serialVersionUID = 8614211550329856579L;
 
-    private static final long serialVersionUID = 8808625867900726781L;
+    private final Node node;
 
-    public CUDAException(int errorCode, String functionName) {
-        super("CUDA error " + errorCode + " in " + functionName);
+    public GrCUDAInternalException(String message) {
+        this(message, null);
     }
 
-    public CUDAException(int errorCode, String message, String functionName) {
-        super(message + '(' + errorCode + ") in " + functionName);
-    }
-
-    public CUDAException(String message) {
+    public GrCUDAInternalException(String message, Node node) {
         super(message);
+        this.node = node;
+    }
+
+    public GrCUDAInternalException(InteropException e) {
+        this(e.getMessage());
+    }
+
+    public boolean isInternalError() {
+        return true;
     }
 
     @Override
     public Node getLocation() {
-        // null = location not available
-        return null;
+        return node;
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDALanguage.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/GrCUDALanguage.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,6 @@
 package com.nvidia.grcuda;
 
 import com.nvidia.grcuda.cuml.CUMLRegistry;
-import com.nvidia.grcuda.gpu.CUDAException;
 import com.nvidia.grcuda.nodes.ExpressionNode;
 import com.nvidia.grcuda.nodes.GrCUDARootNode;
 import com.nvidia.grcuda.parser.ParserAntlr;
@@ -66,7 +65,7 @@ public final class GrCUDALanguage extends TruffleLanguage<GrCUDAContext> {
     }
 
     @Override
-    protected CallTarget parse(ParsingRequest request) throws CUDAException {
+    protected CallTarget parse(ParsingRequest request) {
         ExpressionNode expression = new ParserAntlr().parse(request.getSource());
         GrCUDARootNode newParserRoot = new GrCUDARootNode(this, expression);
         return Truffle.getRuntime().createCallTarget(newParserRoot);

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cuml/CUMLRegistry.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/cuml/CUMLRegistry.java
@@ -181,7 +181,7 @@ public class CUMLRegistry {
             returnCode = INTEROP.asInt(result);
         } catch (UnsupportedMessageException e) {
             CompilerDirectives.transferToInterpreter();
-            throw new GrCUDAInternalException("expected return code as Integer object in " + function + ", got " + result.getClass().getName());
+            throw new GrCUDAInternalException("expected return code as Integer object in " + GrCUDAException.format(function) + ", got " + result.getClass().getName());
         }
         if (returnCode != 0) {
             CompilerDirectives.transferToInterpreter();

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/BindFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/BindFunction.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,8 +28,8 @@
  */
 package com.nvidia.grcuda.functions;
 
+import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.GrCUDALanguage;
-import com.nvidia.grcuda.gpu.CUDAException;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.interop.ArityException;
@@ -54,7 +54,7 @@ public final class BindFunction extends Function {
             return GrCUDALanguage.getCurrentLanguage().getContextReference().get().getCUDARuntime().getSymbol(libraryFile, symbolName, signature);
         } catch (UnknownIdentifierException e) {
             CompilerDirectives.transferToInterpreter();
-            throw new CUDAException(symbolName + " not found in " + libraryFile);
+            throw new GrCUDAException(symbolName + " not found in " + libraryFile);
         }
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayFunction.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/DeviceArrayFunction.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@ import java.util.Optional;
 
 import com.nvidia.grcuda.DeviceArray;
 import com.nvidia.grcuda.ElementType;
+import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.MultiDimDeviceArray;
 import com.nvidia.grcuda.TypeException;
 import com.nvidia.grcuda.gpu.CUDARuntime;
@@ -62,23 +63,21 @@ public final class DeviceArrayFunction extends Function {
             Object arg = arguments[i];
             if (INTEROP.isString(arg)) {
                 if (useColumnMajor.isPresent()) {
-                    throw new RuntimeException("string option already provided");
+                    throw new GrCUDAException("string option already provided");
                 } else {
-                    String strArg = expectString(arg,
-                                    "string argument expected that specifies order ('C' or 'F')");
+                    String strArg = expectString(arg, "string argument expected that specifies order ('C' or 'F')");
                     if (strArg.equals("f") || strArg.equals("F")) {
                         useColumnMajor = Optional.of(true);
                     } else if (strArg.equals("c") || strArg.equals("C")) {
                         useColumnMajor = Optional.of(false);
                     } else {
-                        throw new RuntimeException("invalid string argument '" + strArg +
-                                        "', only \"C\" or \"F\" are allowed");
+                        throw new GrCUDAException("invalid string argument '" + strArg + "', only \"C\" or \"F\" are allowed");
                     }
                 }
             } else {
                 long n = expectLong(arg, "expected number argument for dimension size");
                 if (n < 1) {
-                    throw new RuntimeException("array dimension less than 1");
+                    throw new GrCUDAException("array dimension less than 1");
                 }
                 elementsPerDim.add(n);
             }
@@ -91,7 +90,7 @@ public final class DeviceArrayFunction extends Function {
             long[] dimensions = elementsPerDim.stream().mapToLong(l -> l).toArray();
             return new MultiDimDeviceArray(runtime, elementType, dimensions, useColumnMajor.orElse(false));
         } catch (TypeException e) {
-            throw new RuntimeException(e.getMessage());
+            throw new GrCUDAException(e.getMessage());
         }
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/ExternalFunctionFactory.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/ExternalFunctionFactory.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
  */
 package com.nvidia.grcuda.functions;
 
+import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.gpu.CUDARuntime;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.interop.InteropException;
@@ -68,7 +69,7 @@ public class ExternalFunctionFactory {
                             cudaRuntime.getSymbol(libraryPath, symbolName, nfiSignature));
         } catch (InteropException e) {
             CompilerDirectives.transferToInterpreter();
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/FunctionTable.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/functions/FunctionTable.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@ package com.nvidia.grcuda.functions;
 import java.util.HashMap;
 import java.util.Optional;
 
+import com.nvidia.grcuda.GrCUDAInternalException;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
@@ -43,7 +44,7 @@ public final class FunctionTable {
         String namespace = function.getNamespace();
         String key = getKeyFromName(functionName, namespace);
         if (functionMap.containsKey(key)) {
-            throw new RuntimeException("function '" + namespace + "::" + functionName + "' already exists.");
+            throw new GrCUDAInternalException("function '" + namespace + "::" + functionName + "' already exists.");
         }
         functionMap.put(key, function);
         return this;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import org.graalvm.collections.Pair;
 import com.nvidia.grcuda.GPUPointer;
 import com.nvidia.grcuda.GrCUDAContext;
+import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.NoneValue;
 import com.nvidia.grcuda.functions.CUDAFunction;
 import com.nvidia.grcuda.functions.CUDAFunctionFactory;
@@ -72,15 +73,20 @@ public final class CUDARuntime {
 
     public CUDARuntime(GrCUDAContext context, Env env) {
         this.context = context;
-        TruffleObject libcudart = (TruffleObject) env.parse(
-                        Source.newBuilder("nfi", "load " + "lib" + CUDA_RUNTIME_LIBRARY_NAME + ".so", "cudaruntime").build()).call();
-        TruffleObject libcuda = (TruffleObject) env.parse(
-                        Source.newBuilder("nfi", "load " + "lib" + CUDA_LIBRARY_NAME + ".so", "cuda").build()).call();
-        TruffleObject libnvrtc = (TruffleObject) env.parse(
-                        Source.newBuilder("nfi", "load " + "lib" + NVRTC_LIBRARY_NAME + ".so", "nvrtc").build()).call();
-        loadedLibraries.put(CUDA_RUNTIME_LIBRARY_NAME, libcudart);
-        loadedLibraries.put(CUDA_LIBRARY_NAME, libcuda);
-        loadedLibraries.put(NVRTC_LIBRARY_NAME, libnvrtc);
+        try {
+            TruffleObject libcudart = (TruffleObject) env.parseInternal(
+                            Source.newBuilder("nfi", "load " + "lib" + CUDA_RUNTIME_LIBRARY_NAME + ".so", "cudaruntime").build()).call();
+            TruffleObject libcuda = (TruffleObject) env.parseInternal(
+                            Source.newBuilder("nfi", "load " + "lib" + CUDA_LIBRARY_NAME + ".so", "cuda").build()).call();
+            TruffleObject libnvrtc = (TruffleObject) env.parseInternal(
+                            Source.newBuilder("nfi", "load " + "lib" + NVRTC_LIBRARY_NAME + ".so", "nvrtc").build()).call();
+            loadedLibraries.put(CUDA_RUNTIME_LIBRARY_NAME, libcudart);
+            loadedLibraries.put(CUDA_LIBRARY_NAME, libcuda);
+            loadedLibraries.put(NVRTC_LIBRARY_NAME, libnvrtc);
+        } catch (UnsatisfiedLinkError e) {
+            throw new GrCUDAException(e.getMessage());
+        }
+
         nvrtc = new NVRuntimeCompiler(this);
         context.addDisposable(this::shutdown);
     }
@@ -90,32 +96,28 @@ public final class CUDARuntime {
 
     @TruffleBoundary
     public GPUPointer cudaMalloc(long numBytes) {
-        try {
-            try (UnsafeHelper.PointerObject outPointer = UnsafeHelper.createPointerObject()) {
-                Object callable = getSymbol(CUDARuntimeFunction.CUDA_MALLOC);
-                Object result = INTEROP.execute(callable, outPointer.getAddress(), numBytes);
-                checkCUDAReturnCode(result, "cudaMalloc");
-                long addressAllocatedMemory = outPointer.getValueOfPointer();
-                return new GPUPointer(addressAllocatedMemory);
-            }
+        try (UnsafeHelper.PointerObject outPointer = UnsafeHelper.createPointerObject()) {
+            Object callable = getSymbol(CUDARuntimeFunction.CUDA_MALLOC);
+            Object result = INTEROP.execute(callable, outPointer.getAddress(), numBytes);
+            checkCUDAReturnCode(result, "cudaMalloc");
+            long addressAllocatedMemory = outPointer.getValueOfPointer();
+            return new GPUPointer(addressAllocatedMemory);
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     public LittleEndianNativeArrayView cudaMallocManaged(long numBytes) {
         final int cudaMemAttachGlobal = 0x01;
-        try {
-            try (UnsafeHelper.PointerObject outPointer = UnsafeHelper.createPointerObject()) {
-                Object callable = getSymbol(CUDARuntimeFunction.CUDA_MALLOCMANAGED);
-                Object result = INTEROP.execute(callable, outPointer.getAddress(), numBytes, cudaMemAttachGlobal);
-                checkCUDAReturnCode(result, "cudaMallocManaged");
-                long addressAllocatedMemory = outPointer.getValueOfPointer();
-                return new LittleEndianNativeArrayView(addressAllocatedMemory, numBytes);
-            }
+        try (UnsafeHelper.PointerObject outPointer = UnsafeHelper.createPointerObject()) {
+            Object callable = getSymbol(CUDARuntimeFunction.CUDA_MALLOCMANAGED);
+            Object result = INTEROP.execute(callable, outPointer.getAddress(), numBytes, cudaMemAttachGlobal);
+            checkCUDAReturnCode(result, "cudaMallocManaged");
+            long addressAllocatedMemory = outPointer.getValueOfPointer();
+            return new LittleEndianNativeArrayView(addressAllocatedMemory, numBytes);
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -126,7 +128,7 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, memory.getStartAddress());
             checkCUDAReturnCode(result, "cudaFree");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -137,7 +139,7 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, pointer.getRawPointer());
             checkCUDAReturnCode(result, "cudaFree");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -148,7 +150,7 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable);
             checkCUDAReturnCode(result, "cudaDeviceSynchronize");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -165,24 +167,22 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, destPointer, fromPointer, numBytesToCopy, cudaMemcpyDefault);
             checkCUDAReturnCode(result, "cudaMemcpy");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     public DeviceMemoryInfo cudaMemGetInfo() {
-        try {
-            final String symbol = "cudaMemGetInfo";
-            final String nfiSignature = "(pointer, pointer): sint32";
+        final String symbol = "cudaMemGetInfo";
+        final String nfiSignature = "(pointer, pointer): sint32";
+        try (Integer64Object freeBytes = UnsafeHelper.createInteger64Object();
+                        Integer64Object totalBytes = UnsafeHelper.createInteger64Object()) {
             Object callable = getSymbol(CUDA_RUNTIME_LIBRARY_NAME, symbol, nfiSignature);
-            try (Integer64Object freeBytes = UnsafeHelper.createInteger64Object();
-                            Integer64Object totalBytes = UnsafeHelper.createInteger64Object()) {
-                Object result = INTEROP.execute(callable, freeBytes.getAddress(), totalBytes.getAddress());
-                checkCUDAReturnCode(result, symbol);
-                return new DeviceMemoryInfo(freeBytes.getValue(), totalBytes.getValue());
-            }
+            Object result = INTEROP.execute(callable, freeBytes.getAddress(), totalBytes.getAddress());
+            checkCUDAReturnCode(result, symbol);
+            return new DeviceMemoryInfo(freeBytes.getValue(), totalBytes.getValue());
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -193,21 +193,19 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable);
             checkCUDAReturnCode(result, "cudaDeviceReset");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     public int cudaGetDeviceCount() {
-        try {
-            try (UnsafeHelper.Integer32Object deviceCount = UnsafeHelper.createInteger32Object()) {
-                Object callable = getSymbol(CUDARuntimeFunction.CUDA_GETDEVICECOUNT);
-                Object result = INTEROP.execute(callable, deviceCount.getAddress());
-                checkCUDAReturnCode(result, "cudaGetDeviceCount");
-                return deviceCount.getValue();
-            }
+        try (UnsafeHelper.Integer32Object deviceCount = UnsafeHelper.createInteger32Object()) {
+            Object callable = getSymbol(CUDARuntimeFunction.CUDA_GETDEVICECOUNT);
+            Object result = INTEROP.execute(callable, deviceCount.getAddress());
+            checkCUDAReturnCode(result, "cudaGetDeviceCount");
+            return deviceCount.getValue();
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -218,36 +216,31 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, device);
             checkCUDAReturnCode(result, "cudaSetDevice");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     public int cudaGetDevice() {
-        try {
+        try (Integer32Object deviceId = UnsafeHelper.createInteger32Object()) {
             Object callable = getSymbol(CUDARuntimeFunction.CUDA_GETDEVICE);
-            try (Integer32Object deviceId = UnsafeHelper.createInteger32Object()) {
-                Object result = INTEROP.execute(callable, deviceId.getAddress());
-                checkCUDAReturnCode(result, "cudaGetDevice");
-                return deviceId.getValue();
-            }
-
+            Object result = INTEROP.execute(callable, deviceId.getAddress());
+            checkCUDAReturnCode(result, "cudaGetDevice");
+            return deviceId.getValue();
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     public int cudaDeviceGetAttribute(CUDADeviceAttribute attribute, int deviceId) {
-        try {
+        try (Integer32Object value = UnsafeHelper.createInteger32Object()) {
             Object callable = getSymbol(CUDARuntimeFunction.CUDA_DEVICEGETATTRIBUTE);
-            try (Integer32Object value = UnsafeHelper.createInteger32Object()) {
-                Object result = INTEROP.execute(callable, value.getAddress(), attribute.getAttributeCode(), deviceId);
-                checkCUDAReturnCode(result, "cudaDeviceGetAttribute");
-                return value.getValue();
-            }
+            Object result = INTEROP.execute(callable, value.getAddress(), attribute.getAttributeCode(), deviceId);
+            checkCUDAReturnCode(result, "cudaDeviceGetAttribute");
+            return value.getValue();
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -263,7 +256,7 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, errorCode);
             return INTEROP.asString(result);
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -283,17 +276,22 @@ public final class CUDARuntime {
             // symbol does not exist or not yet bound
             TruffleObject library = loadedLibraries.get(libraryPath);
             if (library == null) {
-                // library does not exist or is not loaded yet
-                library = (TruffleObject) context.getEnv().parse(
-                                Source.newBuilder("nfi", "load \"" + libraryPath + "\"", libraryPath).build()).call();
+                try {
+                    // library does not exist or is not loaded yet
+                    library = (TruffleObject) context.getEnv().parseInternal(
+                                    Source.newBuilder("nfi", "load \"" + libraryPath + "\"", libraryPath).build()).call();
+                } catch (UnsatisfiedLinkError e) {
+                    throw new GrCUDAException("unable to load shared library '" + libraryPath + "': " + e.getMessage());
+                }
+
                 loadedLibraries.put(libraryPath, library);
             }
             Object symbol;
             try {
                 symbol = INTEROP.readMember(library, symbolName);
                 callable = INTEROP.invokeMember(symbol, "bind", signature);
-            } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException e) {
-                throw new RuntimeException("unexpected behavior");
+            } catch (UnsatisfiedLinkError | UnsupportedMessageException | ArityException | UnsupportedTypeException e) {
+                throw new GrCUDAException("unexpected behavior: " + e.getMessage());
             }
             boundFunctions.put(functionKey, callable);
         }
@@ -305,17 +303,15 @@ public final class CUDARuntime {
                         function.getFunctionFactory().getNFISignature());
     }
 
-    private void checkCUDAReturnCode(Object result, String function) {
+    private void checkCUDAReturnCode(Object result, String... function) {
         if (!(result instanceof Integer)) {
             CompilerDirectives.transferToInterpreter();
-            throw new RuntimeException(
-                            "expected return code as Integer object in " + function + ", got " +
-                                            result.getClass().getName());
+            throw new GrCUDAException("expected return code as Integer object in " + function + ", got " + result.getClass().getName());
         }
         Integer returnCode = (Integer) result;
         if (returnCode != 0) {
             CompilerDirectives.transferToInterpreter();
-            throw new CUDAException(returnCode, cudaGetErrorString(returnCode), function);
+            throw new GrCUDAException(returnCode, cudaGetErrorString(returnCode), function);
         }
     }
 
@@ -342,7 +338,7 @@ public final class CUDARuntime {
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                             return value.getValue();
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -362,7 +358,7 @@ public final class CUDARuntime {
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                             return NoneValue.get();
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -382,7 +378,7 @@ public final class CUDARuntime {
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                             return NoneValue.get();
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -403,7 +399,7 @@ public final class CUDARuntime {
                         } else if (pointerObj instanceof LittleEndianNativeArrayView) {
                             addr = ((LittleEndianNativeArrayView) pointerObj).getStartAddress();
                         } else {
-                            throw new RuntimeException("expected GPUPointer or LittleEndianNativeArrayView");
+                            throw new GrCUDAException("expected GPUPointer or LittleEndianNativeArrayView");
                         }
                         try {
                             Object callable = cudaRuntime.getSymbol(CUDARuntimeFunction.CUDA_FREE);
@@ -411,7 +407,7 @@ public final class CUDARuntime {
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                             return NoneValue.get();
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -431,7 +427,7 @@ public final class CUDARuntime {
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                             return deviceId.getValue();
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -451,7 +447,7 @@ public final class CUDARuntime {
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                             return deviceCount.getValue();
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -471,7 +467,7 @@ public final class CUDARuntime {
                             Object result = INTEROP.execute(callable, errorCode);
                             return INTEROP.asString(result);
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -493,7 +489,7 @@ public final class CUDARuntime {
                             long addressAllocatedMemory = outPointer.getValueOfPointer();
                             return new GPUPointer(addressAllocatedMemory);
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -516,7 +512,7 @@ public final class CUDARuntime {
                             long addressAllocatedMemory = outPointer.getValueOfPointer();
                             return new GPUPointer(addressAllocatedMemory);
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                     }
                 };
@@ -536,7 +532,7 @@ public final class CUDARuntime {
                             Object result = INTEROP.execute(callable, device);
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                         return NoneValue.get();
                     }
@@ -562,7 +558,7 @@ public final class CUDARuntime {
                             Object result = INTEROP.execute(callable, destPointer, fromPointer, numBytesToCopy, cudaMemcpyDefault);
                             cudaRuntime.checkCUDAReturnCode(result, getName());
                         } catch (InteropException e) {
-                            throw new RuntimeException(e);
+                            throw new GrCUDAException(e);
                         }
                         return NoneValue.get();
                     }
@@ -627,20 +623,18 @@ public final class CUDARuntime {
     public CUModule cuModuleLoad(String cubinName) {
         assertCUDAInitialized();
         if (loadedModules.containsKey(cubinName)) {
-            throw new IllegalArgumentException("A module for " + cubinName + " was already loaded.");
+            throw new GrCUDAException("A module for " + cubinName + " was already loaded.");
         }
-        try {
-            try (UnsafeHelper.Integer64Object modulePtr = UnsafeHelper.createInteger64Object()) {
-                Object callable = getSymbol(CUDADriverFunction.CU_MODULELOAD);
-                Object result = INTEROP.execute(callable,
-                                modulePtr.getAddress(), cubinName);
-                checkCUReturnCode(result, "cuModuleLoad");
-                CUModule module = new CUModule(cubinName, modulePtr.getValue());
-                loadedModules.put(cubinName, module);
-                return module;
-            }
+        try (UnsafeHelper.Integer64Object modulePtr = UnsafeHelper.createInteger64Object()) {
+            Object callable = getSymbol(CUDADriverFunction.CU_MODULELOAD);
+            Object result = INTEROP.execute(callable,
+                            modulePtr.getAddress(), cubinName);
+            checkCUReturnCode(result, "cuModuleLoad");
+            CUModule module = new CUModule(cubinName, modulePtr.getValue());
+            loadedModules.put(cubinName, module);
+            return module;
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -648,20 +642,18 @@ public final class CUDARuntime {
     public CUModule cuModuleLoadData(String ptx, String moduleName) {
         assertCUDAInitialized();
         if (loadedModules.containsKey(moduleName)) {
-            throw new IllegalArgumentException("A module for " + moduleName + " was already loaded.");
+            throw new GrCUDAException("A module for " + moduleName + " was already loaded.");
         }
-        try {
-            try (UnsafeHelper.Integer64Object modulePtr = UnsafeHelper.createInteger64Object()) {
-                Object callable = getSymbol(CUDADriverFunction.CU_MODULELOADDATA);
-                Object result = INTEROP.execute(callable,
-                                modulePtr.getAddress(), ptx);
-                checkCUReturnCode(result, "cuModuleLoadData");
-                CUModule module = new CUModule(moduleName, modulePtr.getValue());
-                loadedModules.put(moduleName, module);
-                return module;
-            }
+        try (UnsafeHelper.Integer64Object modulePtr = UnsafeHelper.createInteger64Object()) {
+            Object callable = getSymbol(CUDADriverFunction.CU_MODULELOADDATA);
+            Object result = INTEROP.execute(callable,
+                            modulePtr.getAddress(), ptx);
+            checkCUReturnCode(result, "cuModuleLoadData");
+            CUModule module = new CUModule(moduleName, modulePtr.getValue());
+            loadedModules.put(moduleName, module);
+            return module;
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -672,22 +664,20 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, module.module);
             checkCUReturnCode(result, "cuModuleUnload");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     public long cuModuleGetFunction(CUModule kernelModule, String kernelName) {
-        try {
-            try (UnsafeHelper.Integer64Object functionPtr = UnsafeHelper.createInteger64Object()) {
-                Object callable = getSymbol(CUDADriverFunction.CU_MODULEGETFUNCTION);
-                Object result = INTEROP.execute(callable,
-                                functionPtr.getAddress(), kernelModule.module, kernelName);
-                checkCUReturnCode(result, "cuModuleGetFunction");
-                return functionPtr.getValue();
-            }
+        try (UnsafeHelper.Integer64Object functionPtr = UnsafeHelper.createInteger64Object()) {
+            Object callable = getSymbol(CUDADriverFunction.CU_MODULEGETFUNCTION);
+            Object result = INTEROP.execute(callable,
+                            functionPtr.getAddress(), kernelModule.module, kernelName);
+            checkCUReturnCode(result, "cuModuleGetFunction");
+            return functionPtr.getValue();
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -699,7 +689,7 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable);
             checkCUReturnCode(result, "cuCtxSynchronize");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -725,7 +715,7 @@ public final class CUDARuntime {
             checkCUReturnCode(result, "cuLaunchKernel");
             cudaDeviceSynchronize();
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -737,21 +727,19 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, flags);
             checkCUReturnCode(result, "cuInit");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     private int cuDeviceGetCount() {
         try (UnsafeHelper.Integer32Object devCount = UnsafeHelper.createInteger32Object()) {
-            try {
-                Object callable = getSymbol(CUDADriverFunction.CU_DEVICEGETCOUNT);
-                Object result = INTEROP.execute(callable, devCount.getAddress());
-                checkCUReturnCode(result, "cuDeviceGetCount");
-                return devCount.getValue();
-            } catch (InteropException e) {
-                throw new RuntimeException(e);
-            }
+            Object callable = getSymbol(CUDADriverFunction.CU_DEVICEGETCOUNT);
+            Object result = INTEROP.execute(callable, devCount.getAddress());
+            checkCUReturnCode(result, "cuDeviceGetCount");
+            return devCount.getValue();
+        } catch (InteropException e) {
+            throw new GrCUDAException(e);
         }
     }
 
@@ -759,14 +747,12 @@ public final class CUDARuntime {
     private int cuDeviceGet(int deviceOrdinal) {
         assertCUDAInitialized();
         try (UnsafeHelper.Integer32Object deviceObj = UnsafeHelper.createInteger32Object()) {
-            try {
-                Object callable = getSymbol(CUDADriverFunction.CU_DEVICEGET);
-                Object result = INTEROP.execute(callable, deviceObj.getAddress(), deviceOrdinal);
-                checkCUReturnCode(result, "cuDeviceGet");
-                return deviceObj.getValue();
-            } catch (InteropException e) {
-                throw new RuntimeException(e);
-            }
+            Object callable = getSymbol(CUDADriverFunction.CU_DEVICEGET);
+            Object result = INTEROP.execute(callable, deviceObj.getAddress(), deviceOrdinal);
+            checkCUReturnCode(result, "cuDeviceGet");
+            return deviceObj.getValue();
+        } catch (InteropException e) {
+            throw new GrCUDAException(e);
         }
     }
 
@@ -774,42 +760,36 @@ public final class CUDARuntime {
     private String cuDeviceGetName(int cuDeviceId) {
         final int maxLength = 256;
         try (UnsafeHelper.StringObject nameString = new UnsafeHelper.StringObject(maxLength)) {
-            try {
-                Object callable = getSymbol(CUDADriverFunction.CU_DEVICEGETNAME);
-                Object result = INTEROP.execute(callable, nameString.getAddress(), maxLength, cuDeviceId);
-                checkCUReturnCode(result, "cuDeviceGetName");
-                return nameString.getZeroTerminatedString();
-            } catch (InteropException e) {
-                throw new RuntimeException(e);
-            }
+            Object callable = getSymbol(CUDADriverFunction.CU_DEVICEGETNAME);
+            Object result = INTEROP.execute(callable, nameString.getAddress(), maxLength, cuDeviceId);
+            checkCUReturnCode(result, "cuDeviceGetName");
+            return nameString.getZeroTerminatedString();
+        } catch (InteropException e) {
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     private long cuCtxCreate(int flags, int cudevice) {
         try (UnsafeHelper.PointerObject pctx = UnsafeHelper.createPointerObject()) {
-            try {
-                Object callable = getSymbol(CUDADriverFunction.CU_CTXCREATE);
-                Object result = INTEROP.execute(callable, pctx.getAddress(), flags, cudevice);
-                checkCUReturnCode(result, "cuCtxCreate");
-                return pctx.getValueOfPointer();
-            } catch (InteropException e) {
-                throw new RuntimeException(e);
-            }
+            Object callable = getSymbol(CUDADriverFunction.CU_CTXCREATE);
+            Object result = INTEROP.execute(callable, pctx.getAddress(), flags, cudevice);
+            checkCUReturnCode(result, "cuCtxCreate");
+            return pctx.getValueOfPointer();
+        } catch (InteropException e) {
+            throw new GrCUDAException(e);
         }
     }
 
     @TruffleBoundary
     private long cuDevicePrimaryCtxRetain(int cudevice) {
         try (UnsafeHelper.PointerObject pctx = UnsafeHelper.createPointerObject()) {
-            try {
-                Object callable = getSymbol(CUDADriverFunction.CU_DEVICEPRIMARYCTXRETAIN);
-                Object result = INTEROP.execute(callable, pctx.getAddress(), cudevice);
-                checkCUReturnCode(result, "cuDevicePrimaryCtxRetain");
-                return pctx.getValueOfPointer();
-            } catch (InteropException e) {
-                throw new RuntimeException(e);
-            }
+            Object callable = getSymbol(CUDADriverFunction.CU_DEVICEPRIMARYCTXRETAIN);
+            Object result = INTEROP.execute(callable, pctx.getAddress(), cudevice);
+            checkCUReturnCode(result, "cuDevicePrimaryCtxRetain");
+            return pctx.getValueOfPointer();
+        } catch (InteropException e) {
+            throw new GrCUDAException(e);
         }
     }
 
@@ -820,7 +800,7 @@ public final class CUDARuntime {
             Object result = INTEROP.execute(callable, ctx);
             checkCUReturnCode(result, "cuCtxDestroy");
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAException(e);
         }
     }
 
@@ -834,17 +814,18 @@ public final class CUDARuntime {
     }
 
     @SuppressWarnings("static-method")
-    private static void checkCUReturnCode(Object result, String function) {
+    private static void checkCUReturnCode(Object result, String... function) {
         int returnCode;
         try {
             returnCode = INTEROP.asInt(result);
         } catch (UnsupportedMessageException e) {
-            throw new RuntimeException(
-                            "expected return code as Integer object in " + function + ", got " +
+            CompilerDirectives.transferToInterpreter();
+            throw new GrCUDAException(
+                            "expected return code as Integer object in " + GrCUDAException.format(function) + ", got " +
                                             result.getClass().getName());
         }
         if (returnCode != 0) {
-            throw new CUDAException(returnCode, DriverAPIErrorMessages.getString(returnCode), function);
+            throw new GrCUDAException(returnCode, DriverAPIErrorMessages.getString(returnCode), function);
         }
     }
 

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/CUDARuntime.java
@@ -306,7 +306,7 @@ public final class CUDARuntime {
     private void checkCUDAReturnCode(Object result, String... function) {
         if (!(result instanceof Integer)) {
             CompilerDirectives.transferToInterpreter();
-            throw new GrCUDAException("expected return code as Integer object in " + function + ", got " + result.getClass().getName());
+            throw new GrCUDAException("expected return code as Integer object in " + GrCUDAException.format(function) + ", got " + result.getClass().getName());
         }
         Integer returnCode = (Integer) result;
         if (returnCode != 0) {

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Kernel.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/Kernel.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,8 +31,10 @@ package com.nvidia.grcuda.gpu;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+
 import com.nvidia.grcuda.DeviceArray;
 import com.nvidia.grcuda.DeviceArray.MemberSet;
+import com.nvidia.grcuda.GrCUDAInternalException;
 import com.nvidia.grcuda.MultiDimDeviceArray;
 import com.nvidia.grcuda.gpu.UnsafeHelper.MemoryObject;
 import com.oracle.truffle.api.CompilerAsserts;
@@ -287,7 +289,7 @@ public final class Kernel implements TruffleObject {
                 size = access.getArraySize(valueObj);
             } catch (UnsupportedMessageException e) {
                 CompilerDirectives.transferToInterpreter();
-                throw new RuntimeException("unexpected behavior");
+                throw new GrCUDAInternalException("unexpected behavior");
             }
             if (size < 1 || size > 3) {
                 CompilerDirectives.transferToInterpreter();
@@ -301,7 +303,7 @@ public final class Kernel implements TruffleObject {
                     elementObj = access.readArrayElement(valueObj, i);
                 } catch (UnsupportedMessageException e) {
                     CompilerDirectives.transferToInterpreter();
-                    throw new RuntimeException("unexpected behavior");
+                    throw new GrCUDAInternalException("unexpected behavior");
                 } catch (InvalidArrayIndexException e) {
                     CompilerDirectives.transferToInterpreter();
                     throw UnsupportedTypeException.create(new Object[]{valueObj}, argumentName + " needs to have between 1 and 3 elements");

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/NVRuntimeCompiler.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/NVRuntimeCompiler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,11 @@
  */
 package com.nvidia.grcuda.gpu;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
+
+import com.nvidia.grcuda.GrCUDAInternalException;
+import com.nvidia.grcuda.GrCUDALanguage;
 import com.nvidia.grcuda.gpu.UnsafeHelper.PointerArray;
 import com.nvidia.grcuda.gpu.UnsafeHelper.StringObject;
 import com.oracle.truffle.api.CompilerAsserts;
@@ -57,8 +61,9 @@ public class NVRuntimeCompiler {
             NVRTCResult compileResult = nvrtcCompileProgram(program, compileOpts);
             if (compileResult != NVRTCResult.NVRTC_SUCCESS) {
                 String compileLog = getProgramLog(program);
-                System.err.println("compile result: " + compileResult);
-                System.err.println("program log: " + compileLog);
+                PrintStream err = new PrintStream(GrCUDALanguage.getCurrentLanguage().getContextReference().get().getEnv().err());
+                err.println("compile result: " + compileResult);
+                err.println("program log: " + compileLog);
                 throw new NVRTCException(compileResult.errorCode, compileLog);
             }
             String loweredKernelName = nvrtcGetLoweredName(program, kernelName);
@@ -82,7 +87,7 @@ public class NVRuntimeCompiler {
             return program;
         } catch (InteropException e) {
             program.close();
-            throw new RuntimeException(e);
+            throw new GrCUDAInternalException(e);
         }
     }
 
@@ -94,7 +99,7 @@ public class NVRuntimeCompiler {
             Object result = INTEROP.execute(callable, program.getValue(), name);
             checkNVRTCReturnCode(result, function.symbolName);
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAInternalException(e);
         }
     }
 
@@ -131,7 +136,7 @@ public class NVRuntimeCompiler {
                             numOpts, addressOfOptStringPointerArray);
             return toNVRTCResult(result);
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAInternalException(e);
         }
     }
 
@@ -146,10 +151,10 @@ public class NVRuntimeCompiler {
                 checkNVRTCReturnCode(result, NVRTCFunction.NVRTC_GETPROGRAMLOGSIZE.symbolName);
                 logSize = (int) sizeBytes.getValue();
                 if (logSize < 0 || logSize > MAX_LOG_SIZE) {  // upper limit to prevent OoM
-                    throw new RuntimeException("Invalid string allocation length " + logSize + ", expected <1 MB");
+                    throw new GrCUDAInternalException("Invalid string allocation length " + logSize + ", expected <1 MB");
                 }
             } catch (InteropException e) {
-                throw new RuntimeException(e);
+                throw new GrCUDAInternalException(e);
             }
         }
         try (UnsafeHelper.StringObject buffer = UnsafeHelper.createStringObject(logSize)) {
@@ -159,7 +164,7 @@ public class NVRuntimeCompiler {
                 checkNVRTCReturnCode(result, NVRTCFunction.NVRTC_GETPROGRAMLOG.symbolName);
                 return buffer.getZeroTerminatedString();
             } catch (InteropException e) {
-                throw new RuntimeException(e);
+                throw new GrCUDAInternalException(e);
             }
         }
     }
@@ -175,10 +180,10 @@ public class NVRuntimeCompiler {
                 checkNVRTCReturnCode(result, NVRTCFunction.NVRTC_GETPTXSIZE.symbolName);
                 ptxSize = (int) sizeBytes.getValue();
                 if (ptxSize < 0 || ptxSize > MAX_LOG_SIZE) {  // upper limit to prevent OoM
-                    throw new RuntimeException("Invalid string allocation length " + ptxSize + ", expected <1 MB");
+                    throw new GrCUDAInternalException("Invalid string allocation length " + ptxSize + ", expected <1 MB");
                 }
             } catch (InteropException e) {
-                throw new RuntimeException(e);
+                throw new GrCUDAInternalException(e);
             }
         }
         try (UnsafeHelper.StringObject buffer = UnsafeHelper.createStringObject(ptxSize)) {
@@ -188,7 +193,7 @@ public class NVRuntimeCompiler {
                 checkNVRTCReturnCode(result, NVRTCFunction.NVRTC_GETPTX.symbolName);
                 return buffer.getZeroTerminatedString();
             } catch (InteropException e) {
-                throw new RuntimeException(e);
+                throw new GrCUDAInternalException(e);
             }
         }
     }
@@ -202,7 +207,7 @@ public class NVRuntimeCompiler {
                 checkNVRTCReturnCode(result, NVRTCFunction.NVRTC_GETLOWEREDNAME.symbolName);
                 return UnsafeHelper.StringObject.getUncheckedZeroTerminatedString(cString.getValueOfPointer());
             } catch (InteropException e) {
-                throw new RuntimeException(e);
+                throw new GrCUDAInternalException(e);
             }
         }
     }
@@ -215,7 +220,7 @@ public class NVRuntimeCompiler {
             Object result = INTEROP.execute(callable, errorCode);
             return INTEROP.asString(result);
         } catch (InteropException e) {
-            throw new RuntimeException(e);
+            throw new GrCUDAInternalException(e);
         }
     }
 
@@ -226,7 +231,7 @@ public class NVRuntimeCompiler {
     private void checkNVRTCReturnCode(Object result, String functionName) {
         CompilerAsserts.neverPartOfCompilation();
         if (!(result instanceof Integer)) {
-            throw new RuntimeException(
+            throw new GrCUDAInternalException(
                             "expected return code as Integer object in " + functionName + ", got " +
                                             result.getClass().getName());
         }
@@ -239,7 +244,7 @@ public class NVRuntimeCompiler {
     private static NVRTCResult toNVRTCResult(Object result) {
         CompilerAsserts.neverPartOfCompilation();
         if (!(result instanceof Integer)) {
-            throw new RuntimeException(
+            throw new GrCUDAInternalException(
                             "expected return code as Integer object for nvrtcResult, got " +
                                             result.getClass().getName());
         }
@@ -281,7 +286,7 @@ public class NVRuntimeCompiler {
                 Object result = INTEROP.execute(callable, nvrtcProgram.getAddress());
                 checkNVRTCReturnCode(result, function.symbolName);
             } catch (InteropException e) {
-                throw new RuntimeException(e);
+                throw new GrCUDAInternalException(e);
             } finally {
                 nvrtcProgram.close();
             }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/OffheapMemory.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/OffheapMemory.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -70,6 +71,7 @@ public final class OffheapMemory implements AutoCloseable {
             f.setAccessible(true);
             unsafe = (Unsafe) f.get(null);
         } catch (NoSuchFieldException | IllegalAccessException e) {
+            // this needs to be a RuntimeException since it is raised during static initialization
             throw new RuntimeException(e);
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/UnsafeHelper.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/gpu/UnsafeHelper.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,6 +46,7 @@ public class UnsafeHelper {
             f.setAccessible(true);
             unsafe = (Unsafe) f.get(null);
         } catch (NoSuchFieldException | IllegalAccessException e) {
+            // this needs to be a RuntimeException since it is raised during static initialization
             throw new RuntimeException(e);
         }
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArithmeticNode.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArithmeticNode.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,8 @@
  */
 package com.nvidia.grcuda.nodes;
 
+import com.nvidia.grcuda.GrCUDAException;
+import com.nvidia.grcuda.GrCUDAInternalException;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
@@ -55,7 +57,7 @@ public final class ArithmeticNode extends BinaryNode {
         Object right = rightNode.execute(frame);
         if (!(left instanceof Number) || !(right instanceof Number)) {
             CompilerDirectives.transferToInterpreter();
-            throw new RuntimeException("operation expects integer types");
+            throw new GrCUDAException("operation expects integer types", this);
         }
         int leftInt = ((Number) left).intValue();
         int rightInt = ((Number) right).intValue();
@@ -73,6 +75,6 @@ public final class ArithmeticNode extends BinaryNode {
                 return leftInt % rightInt;
         }
         CompilerDirectives.transferToInterpreter();
-        throw new RuntimeException("fall-through in ArithmeticNode");
+        throw new GrCUDAInternalException("fall-through in ArithmeticNode", this);
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArrayNode.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/ArrayNode.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,9 +29,11 @@
 package com.nvidia.grcuda.nodes;
 
 import java.util.ArrayList;
+
 import com.nvidia.grcuda.DeviceArray;
 import com.nvidia.grcuda.ElementType;
 import com.nvidia.grcuda.GrCUDAContext;
+import com.nvidia.grcuda.GrCUDAInternalException;
 import com.nvidia.grcuda.GrCUDALanguage;
 import com.nvidia.grcuda.MultiDimDeviceArray;
 import com.nvidia.grcuda.gpu.CUDARuntime;
@@ -62,7 +64,7 @@ public abstract class ArrayNode extends ExpressionNode {
             Object size = sizeNode.execute(frame);
             if (!(size instanceof Number)) {
                 CompilerDirectives.transferToInterpreter();
-                throw new RuntimeException("size in dimension " + dim + " must be a number");
+                throw new GrCUDAInternalException("size in dimension " + dim + " must be a number", this);
             }
             elementsPerDim[dim] = ((Number) size).longValue();
             dim += 1;

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/CallNode.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/CallNode.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,7 +76,7 @@ public abstract class CallNode extends ExpressionNode {
             return interop.execute(function, argumentValues);
         } catch (ArityException | UnsupportedTypeException | UnsupportedMessageException e) {
             CompilerDirectives.transferToInterpreter();
-            throw new RuntimeException((e));
+            throw new GrCUDAException(e.getMessage(), this);
         }
     }
 }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/IdentifierNode.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/nodes/IdentifierNode.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,9 @@
 package com.nvidia.grcuda.nodes;
 
 import java.util.Optional;
+
 import com.nvidia.grcuda.GrCUDAContext;
+import com.nvidia.grcuda.GrCUDAException;
 import com.nvidia.grcuda.GrCUDALanguage;
 import com.nvidia.grcuda.functions.Function;
 import com.nvidia.grcuda.functions.FunctionTable;
@@ -66,7 +68,7 @@ public abstract class IdentifierNode extends ExpressionNode {
         Optional<Function> maybeFunction = functionTable.lookupFunction(identifierName, namespace);
         if (!maybeFunction.isPresent()) {
             CompilerDirectives.transferToInterpreter();
-            throw new RuntimeException("Function '" + identifierName + "' not found in namespace '" + namespace + "'");
+            throw new GrCUDAException("Function '" + identifierName + "' not found in namespace '" + namespace + "'");
         }
         return maybeFunction.get();
     }

--- a/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/parser/NodeFactory.java
+++ b/projects/com.nvidia.grcuda/src/com/nvidia/grcuda/parser/NodeFactory.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@ package com.nvidia.grcuda.parser;
 import java.util.ArrayList;
 import org.antlr.v4.runtime.Token;
 import com.nvidia.grcuda.ElementType;
+import com.nvidia.grcuda.GrCUDAInternalException;
 import com.nvidia.grcuda.TypeException;
 import com.nvidia.grcuda.nodes.ArithmeticNode;
 import com.nvidia.grcuda.nodes.ArrayNode;
@@ -76,7 +77,7 @@ public class NodeFactory {
                 break;
             default:
                 // should not happen due to lexer
-                throw new RuntimeException("unexpected operation: " + opToken.getText());
+                throw new GrCUDAInternalException("unexpected operation: " + opToken.getText());
         }
         return result;
     }
@@ -99,7 +100,7 @@ public class NodeFactory {
             return new IntegerLiteral(Integer.parseInt(literalToken.getText()));
         } catch (NumberFormatException e) {
             // ignore parse error cannot happen due to regular expression in lexer
-            throw new RuntimeException("unable to parse integer literal " + e.getMessage());
+            throw new GrCUDAInternalException("unable to parse integer literal " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
This PR pulls out the changes to exception handling (don't throw `RuntimeExceptions`) from https://github.com/NVIDIA/grcuda/pull/18.
It also changes the deprecated `parse` calls to `parseInternal`, adds some minor code simplifications in `CUDARuntime`, and replaces the usages of `System.err` in `NVRuntimeCompiler` with `TruffleLanguage.Env.err`.