### PR TITLE
Adds Mandelbrot web application example from NVIDIA Developer Blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ workingsets.xml
 GRCUDA.dist
 GRCUDA_UNIT_TESTS.dist
 mx.grcuda/eclipse-launches
-*.json
 .checkstyle
 *.bc
 *.iml

--- a/examples/mandelbrot/README.md
+++ b/examples/mandelbrot/README.md
@@ -1,0 +1,24 @@
+# Mandelbrot Web Application with Express
+
+This example demonstrates how grCUDA can be used in a Node.js
+web application with the Express framework.
+
+The code is described in the
+[NVIDIA Developer Blog on grCUDA](https://devblogs.nvidia.com/grcuda-a-polyglot-language-binding-for-cuda-in-graalvm/).
+For more details, see the blog.
+
+## How to run the Example
+
+```console
+$ npm i
+added 272 packages from 152 contributors and audited 272 packages in 90.639s
+
+26 packages are looking for funding                                                                       run `npm fund` for details
+
+found 0 vulnerabilities
+
+$ node --polyglot --jvm \
+  --vm.Dtruffle.class.path.append=../../mxbuild/dists/jdk1.8/grcuda.jar \
+  app.js
+Mandelbrot app listening on port 3000!
+```

--- a/examples/mandelbrot/app.js
+++ b/examples/mandelbrot/app.js
@@ -1,0 +1,71 @@
+/* Copyright (c) 1993-2019, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+const express = require('express')
+const app = express()
+
+const kernelSrc = `
+__global__ void mandelbrot(int *img, int width_pixel, int height_pixel,
+                           float w, float h, float x0, float y0, int max_iter) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  const int y = blockIdx.y * blockDim.y + threadIdx.y;
+  float c_re = (w / width_pixel) * (x - width_pixel / 2) + x0;
+  float c_im = (h / height_pixel) * (height_pixel / 2 - y) + y0;
+  float z_re = 0, z_im = 0;
+  int iter = 0;
+  while ((z_re * z_re + z_im * z_im <= 4) && (iter < max_iter)) {
+    float z_re_new = z_re * z_re - z_im * z_im + c_re;
+    z_im = 2 * z_re * z_im + c_im;
+    z_re = z_re_new;
+    iter += 1;
+  }
+  img[y * width_pixel + x] = (iter == max_iter);
+}`
+const port = 3000
+const widthPixels = 128
+const heightPixels = 64
+const cu = Polyglot.eval('grcuda', 'CU')
+const kernel = cu.buildkernel(kernelSrc, 'mandelbrot',
+  'pointer, sint32, sint32, float, float, float, float, sint32')
+const blockSize = [32, 8] // thread block with 32x8 threads
+const grid = [widthPixels / blockSize[0], heightPixels / blockSize[1]]
+const kernelWithGrid = kernel(grid, blockSize)
+
+app.get('/', (req, res) => {
+  const img = cu.DeviceArray('int', heightPixels, widthPixels)
+  kernelWithGrid(img, widthPixels, heightPixels, 3.0, 2.0, -0.5, 0.0, 255)
+  var textImg = ''
+  for (var y = 0; y < heightPixels; y++) {
+    for (var x = 0; x < widthPixels; x++) {
+      textImg += (img[y][x] === 1) ? '*' : ' '
+    }
+    textImg += '\n'
+  }
+  res.setHeader('Content-Type', 'text/plain')
+  res.send(textImg)
+})
+
+app.listen(port, () => console.log(`Mandelbrot app listening on port ${port}!`))

--- a/examples/mandelbrot/license.txt
+++ b/examples/mandelbrot/license.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 1993-2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/mandelbrot/package.json
+++ b/examples/mandelbrot/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mandelbrot",
+  "version": "0.1.0",
+  "description": "Mandelbrot Set as ASCII Art",
+  "main": "app.js",
+  "repository": "https://github.com/NVIDIA/grcuda/examples/mandelbrot",
+  "scripts": {},
+  "author": "",
+  "license": "SEE LICENSE IN license.txt",
+  "dependencies": {
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "standard": "^14.3.3"
+  }
+}


### PR DESCRIPTION
This PR address the Mandelbrot web application example presented in the [NVIDIA Developer Blog on grCUDA](https://devblogs.nvidia.com/grcuda-a-polyglot-language-binding-for-cuda-in-graalvm/).

The JavaScript source code from the [repo for the blog](https://github.com/NVIDIA-developer-blog/code-samples/tree/master/posts/grcuda/mandelbrot) was modernized to use the `CU` root namespace object to access the grCUDA functions.